### PR TITLE
Add Ruby-GCCcore-10.3.0.eb to NESSI/2022.11

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -424,7 +424,7 @@ echo_green "All set, let's start installing some software in ${EASYBUILD_INSTALL
 #$EB Perl-5.32.1-GCCcore-10.3.0.eb --robot --include-easyblocks-from-pr 2640
 #use enhanced CMake easyblock to patch CMake's UnixPaths.cmake script if --sysroot is set
 #from https://github.com/easybuilders/easybuild-easyblocks/pull/2248
-$EB CMake-3.20.1-GCCcore-10.3.0.eb --robot --include-easyblocks-from-pr 2248
+#$EB CMake-3.20.1-GCCcore-10.3.0.eb --robot --include-easyblocks-from-pr 2248
 # use Rust easyconfig from https://github.com/easybuilders/easybuild-easyconfigs/pull/14584
 # that includes patch to fix bootstrap problem when using alternate sysroot
 #$EB --from-pr 14584 Rust-1.52.1-GCCcore-10.3.0.eb --robot
@@ -449,6 +449,7 @@ $EB CMake-3.20.1-GCCcore-10.3.0.eb --robot --include-easyblocks-from-pr 2248
 #####################
 ### add packages here
 #####################
+$EB Ruby-3.0.1-GCCcore-10.3.0.eb --robot
 # example block showing a few debugging means
 #echo "Installing CaDiCaL/1.3.0 for GCC/9.3.0..."
 #ok_msg="CaDiCaL installed. Nice!"

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -424,7 +424,7 @@ echo_green "All set, let's start installing some software in ${EASYBUILD_INSTALL
 #$EB Perl-5.32.1-GCCcore-10.3.0.eb --robot --include-easyblocks-from-pr 2640
 #use enhanced CMake easyblock to patch CMake's UnixPaths.cmake script if --sysroot is set
 #from https://github.com/easybuilders/easybuild-easyblocks/pull/2248
-#$EB CMake-3.20.1-GCCcore-10.3.0.eb --robot --include-easyblocks-from-pr 2248
+$EB CMake-3.20.1-GCCcore-10.3.0.eb --robot --include-easyblocks-from-pr 2248
 # use Rust easyconfig from https://github.com/easybuilders/easybuild-easyconfigs/pull/14584
 # that includes patch to fix bootstrap problem when using alternate sysroot
 #$EB --from-pr 14584 Rust-1.52.1-GCCcore-10.3.0.eb --robot

--- a/eessi-2022.11.yml
+++ b/eessi-2022.11.yml
@@ -1,3 +1,4 @@
 easyconfigs:
   - EasyBuild-4.7.0.eb
+  - CMake-3.20.1-GCCcore-10.3.0.eb
   - Ruby-3.0.1-GCCcore-10.3.0.eb

--- a/eessi-2022.11.yml
+++ b/eessi-2022.11.yml
@@ -1,3 +1,3 @@
 easyconfigs:
   - EasyBuild-4.7.0.eb
-  - CMake-3.20.1-GCCcore-10.3.0.eb
+  - Ruby-3.0.1-GCCcore-10.3.0.eb


### PR DESCRIPTION
Trying to add Ruby-GCCcore-10.3.0.eb to NESSI/2022.11