### PR TITLE
Add expat/2.2.9 with GCC/10.3.0 to NESSI/2022.11

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -450,6 +450,7 @@ $EB CMake-3.20.1-GCCcore-10.3.0.eb --robot --include-easyblocks-from-pr 2248
 ### add packages here
 #####################
 $EB Python-3.9.5-GCCcore-10.3.0.eb --robot
+$EB expat-2.2.9-GCCcore-10.3.0.eb  --robot
 # example block showing a few debugging means
 #echo "Installing CaDiCaL/1.3.0 for GCC/9.3.0..."
 #ok_msg="CaDiCaL installed. Nice!"

--- a/eessi-2022.11.yml
+++ b/eessi-2022.11.yml
@@ -2,3 +2,4 @@ easyconfigs:
   - EasyBuild-4.7.0.eb
   - CMake-3.20.1-GCCcore-10.3.0.eb
   - Python-3.9.5-GCCcore-10.3.0.eb
+  - expat-2.2.9-GCCcore-10.3.0.eb 


### PR DESCRIPTION
Trying to add expat/2.2.9 with GCC/10.3.0 to NESSI/2022.11