### PR TITLE
Replay PR20 (Python 3.9.5) to investigate builds for `generic`

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -449,7 +449,7 @@ $EB CMake-3.20.1-GCCcore-10.3.0.eb --robot --include-easyblocks-from-pr 2248
 #####################
 ### add packages here
 #####################
-$EB Python-3.9.5-GCCcore-10.3.0.eb --robot --disable-cleanup-tmpdir
+$EB Python-3.9.5-GCCcore-10.3.0.eb --robot --disable-cleanup-tmpdir --rebuild
 # example block showing a few debugging means
 #echo "Installing CaDiCaL/1.3.0 for GCC/9.3.0..."
 #ok_msg="CaDiCaL installed. Nice!"

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -449,7 +449,7 @@ $EB CMake-3.20.1-GCCcore-10.3.0.eb --robot --include-easyblocks-from-pr 2248
 #####################
 ### add packages here
 #####################
-$EB Python-3.9.5-GCCcore-10.3.0.eb --robot
+$EB Python-3.9.5-GCCcore-10.3.0.eb --robot --disable-cleanup-tmpdir
 # example block showing a few debugging means
 #echo "Installing CaDiCaL/1.3.0 for GCC/9.3.0..."
 #ok_msg="CaDiCaL installed. Nice!"

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -141,6 +141,11 @@ REPOSITORY_OPT=
 if [[ ! -z ${REPOSITORY} ]]; then
     REPOSITORY_OPT="--repository ${REPOSITORY}"
 fi
+GENERIC_OPT=
+if [[ ${EESSI_SOFTWARE_SUBDIR_OVERRIDE} =~ ".*/generic" ]]; then
+    GENERIC_OPT="--generic"
+fi
+
 mkdir -p previous_tmp/{build_step,tarball_step}
 build_outerr=$(mktemp build.outerr.XXXX)
 echo "Executing command to build software:"
@@ -153,7 +158,7 @@ echo "                     --mode run"
 echo "                     ${REPOSITORY_OPT}"
 echo "                     --save ${PWD}/previous_tmp/build_step"
 echo "                     --storage ${STORAGE}"
-echo "                     ./install_software_layer.sh \"$@\" 2>&1 | tee -a ${build_outerr}"
+echo "                     ./install_software_layer.sh ${GENERIC_OPT} \"$@\" 2>&1 | tee -a ${build_outerr}"
 # set EESSI_REPOS_CFG_DIR_OVERRIDE to ./cfg
 export EESSI_REPOS_CFG_DIR_OVERRIDE=${PWD}/cfg
 ./eessi_container.sh --access rw \
@@ -165,7 +170,7 @@ export EESSI_REPOS_CFG_DIR_OVERRIDE=${PWD}/cfg
                      ${REPOSITORY_OPT} \
                      --save ${PWD}/previous_tmp/build_step \
                      --storage ${STORAGE} \
-                     ./install_software_layer.sh "$@" 2>&1 | tee -a ${build_outerr}
+                     ./install_software_layer.sh ${GENERIC_OPT} "$@" 2>&1 | tee -a ${build_outerr}
 
 # determine temporary directory to resume from
 BUILD_TMPDIR=$(grep 'RESUME_FROM_DIR' ${build_outerr} | sed -e "s/^RESUME_FROM_DIR //")

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -158,7 +158,7 @@ echo "                     --mode run"
 echo "                     ${REPOSITORY_OPT}"
 echo "                     --save ${PWD}/previous_tmp/build_step"
 echo "                     --storage ${STORAGE}"
-echo "                     ./install_software_layer.sh ${GENERIC_OPT} \"$@\" 2>&1 | tee -a ${build_outerr}"
+echo "                     -- ./install_software_layer.sh ${GENERIC_OPT} \"$@\" 2>&1 | tee -a ${build_outerr}"
 # set EESSI_REPOS_CFG_DIR_OVERRIDE to ./cfg
 export EESSI_REPOS_CFG_DIR_OVERRIDE=${PWD}/cfg
 ./eessi_container.sh --access rw \
@@ -170,7 +170,7 @@ export EESSI_REPOS_CFG_DIR_OVERRIDE=${PWD}/cfg
                      ${REPOSITORY_OPT} \
                      --save ${PWD}/previous_tmp/build_step \
                      --storage ${STORAGE} \
-                     ./install_software_layer.sh ${GENERIC_OPT} "$@" 2>&1 | tee -a ${build_outerr}
+                     -- ./install_software_layer.sh ${GENERIC_OPT} "$@" 2>&1 | tee -a ${build_outerr}
 
 # determine temporary directory to resume from
 BUILD_TMPDIR=$(grep 'RESUME_FROM_DIR' ${build_outerr} | sed -e "s/^RESUME_FROM_DIR //")

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -142,7 +142,7 @@ if [[ ! -z ${REPOSITORY} ]]; then
     REPOSITORY_OPT="--repository ${REPOSITORY}"
 fi
 GENERIC_OPT=
-if [[ ${EESSI_SOFTWARE_SUBDIR_OVERRIDE} =~ ".*/generic" ]]; then
+if [[ ${EESSI_SOFTWARE_SUBDIR_OVERRIDE} =~ .*/generic$ ]]; then
     GENERIC_OPT="--generic"
 fi
 

--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -114,6 +114,8 @@ SAVE=
 HTTP_PROXY=${http_proxy:-}
 HTTPS_PROXY=${https_proxy:-}
 
+COMMAND_SEPARATOR=0
+
 POSITIONAL_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -172,8 +174,17 @@ while [[ $# -gt 0 ]]; do
       export https_proxy=${HTTPS_PROXY}
       shift 2
       ;;
+    --)
+      COMMAND_SEPARATOR=1
+      shift
+      ;;
     -*|--*)
-      fatal_error "Unknown option: $1" "${CMDLINE_ARG_UNKNOWN_EXITCODE}"
+      if [[ ${COMMAND_SEPARATOR} -eq 0 ]]; then
+        fatal_error "Unknown option: $1" "${CMDLINE_ARG_UNKNOWN_EXITCODE}"
+      else
+        POSITIONAL_ARGS+=("$1") # save positional arg
+        shift
+      fi
       ;;
     *)  # No more options
       POSITIONAL_ARGS+=("$1") # save positional arg


### PR DESCRIPTION
- What we built for `generic` via PR #20 may not always work on _old_ architectures.
- A simple test is
  ```bash
  EESSI_SOFTWARE_SUBDIR_OVERRIDE=x86_64/generic source /cvmfs/pilot.nessi.no/latest/init/bash
  ml Python
  ls -l $(which python)
  python -c "import os; print(os.__file__)"
  ```
  results in `Illegal instruction (core dumped)`
- For example, what we built on `skylake_avx512` doesn't work on `haswell` supposedly because we didn't set `EASYBUILD_OPTARCH=GENERIC`. However, what we built on `broadwell` worked on `haswell` (despite `haswell` being older than `broadwell` ... maybe just not much older).
- With this PR we are rebuilding Python with `EASYBUILD_OPTARCH=GENERIC` to check if it has any influence on the result of the test.
- So after it has been built we need to ingest the `generic` built on `skylake_avx512` (e.g. built on Saga) and repeat the test.