### PR TITLE
Add SciPy-bundle/2021.05 with GCC/10.3.0 to NESSI/2022.11

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -442,7 +442,7 @@ $EB CMake-3.20.1-GCCcore-10.3.0.eb --robot --include-easyblocks-from-pr 2248
 #    $EB FlexiBLAS-3.0.4-GCC-10.3.0.eb
 #fi
 #
-#$EB SciPy-bundle-2021.05-foss-2021a.eb --robot
+$EB SciPy-bundle-2021.05-foss-2021a.eb --robot
 #check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 

--- a/eessi-2022.11.yml
+++ b/eessi-2022.11.yml
@@ -4,3 +4,4 @@ easyconfigs:
   - Python-3.9.5-GCCcore-10.3.0.eb
   - OpenMPI-4.1.1-GCC-10.3.0.eb
   - ImageMagick-7.0.11-14-GCCcore-10.3.0.eb
+  - SciPy-bundle-2021.05-foss-2021a.eb


### PR DESCRIPTION
Trying to add SciPy-bundle/2021.05 with GCC/10.3.0 to NESSI/2022.11