### PR TITLE
pull in fixes from EESSI/software-layer PR238 and PR239

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -177,10 +177,6 @@ else
     eb --install-latest-eb-release &> ${eb_install_out}
     check_exit_code $? "${ok_msg}" "${fail_msg}"
 
-    # restore origin $PATH and $PYTHONPATH values
-    export PATH=${ORIG_PATH}
-    export PYTHONPATH=${ORIG_PYTHONPATH}
-
     eb --search EasyBuild-${REQ_EB_VERSION}.eb | grep EasyBuild-${REQ_EB_VERSION}.eb > /dev/null
     if [[ $? -eq 0 ]]; then
         ok_msg="EasyBuild v${REQ_EB_VERSION} installed, alright!"
@@ -188,6 +184,10 @@ else
         eb EasyBuild-${REQ_EB_VERSION}.eb >> ${eb_install_out} 2>&1
         check_exit_code $? "${ok_msg}" "${fail_msg}"
     fi
+
+    # restore origin $PATH and $PYTHONPATH values
+    export PATH=${ORIG_PATH}
+    export PYTHONPATH=${ORIG_PYTHONPATH}
 
     module avail easybuild/${REQ_EB_VERSION} &> ${ml_av_easybuild_out}
     if [[ $? -eq 0 ]]; then

--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -55,7 +55,7 @@ if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules ]; then
         | grep -v '/\.wh\.' | sed -e 's/.lua$//' | awk -F'/' '{printf "%s/%s\n", $(NF-1), $NF}' | sort | uniq \
         >> ${module_files_list}
 fi
-if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software ]; then
+if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software -a -r ${module_files_list} ]; then
     # installation directories but only those for which module files were created
     for package_version in $(cat ${module_files_list}); do
         echo "handling ${package_version}"
@@ -66,9 +66,9 @@ fi
 
 # add a bit debug output
 echo "wrote file list to ${files_list}"
-cat ${files_list}
+[ -r ${files_list} ] && cat ${files_list}
 echo "wrote module file list to ${module_files_list}"
-cat ${module_files_list}
+[ -r ${module_files_list} ] && cat ${module_files_list}
 
 topdir=${cvmfs_repo}/versions/
 

--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -38,6 +38,7 @@ cd ${overlay_upper_dir}/versions/
 echo ">> Collecting list of files/directories to include in tarball via ${PWD}..."
 
 files_list=${tmpdir}/files.list.txt
+module_files_list=${tmpdir}/module_files.list.txt
 
 if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/.lmod ]; then
     # include Lmod cache and configuration file (lmodrc.lua),
@@ -49,11 +50,25 @@ if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules ]; then
     find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules -type f | grep -v '/\.wh\.' >> ${files_list}
     # module symlinks
     find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules -type l | grep -v '/\.wh\.' >> ${files_list}
+    # module files and symlinks
+    find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules -type f -o -type l \
+        | grep -v '/\.wh\.' | sed -e 's/.lua$//' | awk -F'/' '{printf "%s/%s\n", $(NF-1), $NF}' | sort | uniq \
+        >> ${module_files_list}
 fi
 if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software ]; then
     # installation directories
-    ls -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software/*/* | grep -v '/\.wh\.' >> ${files_list}
+    # ls -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software/*/* | grep -v '/\.wh\.' >> ${files_list}
+    for package_version in $(cat ${module_files_list}); do
+        echo "handling ${package_version}"
+        ls -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software/${package_version} \
+            | grep -v '/\.wh\.' >> ${files_list}
+    done
 fi
+
+echo "wrote file list to ${files_list}"
+cat ${files_list}
+echo "wrote module file list to ${module_files_list}"
+cat ${module_files_list}
 
 topdir=${cvmfs_repo}/versions/
 

--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -51,13 +51,12 @@ if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules ]; then
     # module symlinks
     find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules -type l | grep -v '/\.wh\.' >> ${files_list}
     # module files and symlinks
-    find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules -type f -o -type l \
+    find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules/all -type f -o -type l \
         | grep -v '/\.wh\.' | sed -e 's/.lua$//' | awk -F'/' '{printf "%s/%s\n", $(NF-1), $NF}' | sort | uniq \
         >> ${module_files_list}
 fi
 if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software ]; then
-    # installation directories
-    # ls -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software/*/* | grep -v '/\.wh\.' >> ${files_list}
+    # installation directories but only those for which module files were created
     for package_version in $(cat ${module_files_list}); do
         echo "handling ${package_version}"
         ls -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software/${package_version} \
@@ -65,6 +64,7 @@ if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software ]; then
     done
 fi
 
+# add a bit debug output
 echo "wrote file list to ${files_list}"
 cat ${files_list}
 echo "wrote module file list to ${module_files_list}"


### PR DESCRIPTION
- https://github.com/EESSI/software-layer/pull/238 fixes the issue that `eb` cannot be found
- https://github.com/EESSI/software-layer/pull/239 fixes the issue that packages that already existed are included in a tarball when some file was added to the writable overlay (e.g., a `*.pyc`)