### PR TITLE
add CMake 3.16.4 with GCC/9.3.0 for generic architectures

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -241,11 +241,11 @@ $EB ${GCC_EC} --robot --from-pr 14453 GCCcore-9.3.0.eb
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 # install CMake with custom easyblock that patches CMake when --sysroot is used
-#echo ">> Install CMake with fixed easyblock to take into account --sysroot"
-#ok_msg="CMake installed!"
-#fail_msg="Installation of CMake failed, what the ..."
-#$EB CMake-3.16.4-GCCcore-9.3.0.eb --robot --include-easyblocks-from-pr 2248
-#check_exit_code $? "${ok_msg}" "${fail_msg}"
+echo ">> Install CMake with fixed easyblock to take into account --sysroot"
+ok_msg="CMake installed!"
+fail_msg="Installation of CMake failed, what the ..."
+$EB CMake-3.16.4-GCCcore-9.3.0.eb --robot --include-easyblocks-from-pr 2248
+check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 # If we're building OpenBLAS for GENERIC, we need https://github.com/easybuilders/easybuild-easyblocks/pull/1946
 #echo ">> Installing OpenBLAS..."

--- a/eessi-2022.11.yml
+++ b/eessi-2022.11.yml
@@ -5,3 +5,4 @@ easyconfigs:
   - Java-17.eb
   - GCC-9.3.0.eb
   - GCC-10.3.0.eb
+  - CMake-3.16.4-GCCcore-9.3.0.eb


### PR DESCRIPTION
- building this CMake version seemed to be problematic in #58 and #61 
- we may compare with #57 where it was building recently