### PR TITLE
Merge lmod cache update back to dev branch

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -477,7 +477,7 @@ exit_code=$?
 check_exit_code ${exit_code} "${ok_msg}" "${fail_msg}"
 
 
-echo ">> Creating/updating Lmod cache..."
+echo ">> Creating/updating Lmod cache on $(date) ..."
 export LMOD_RC="${EASYBUILD_INSTALLPATH}/.lmod/lmodrc.lua"
 if [ ! -f $LMOD_RC ]; then
     python3 $TOPDIR/create_lmodrc.py ${EASYBUILD_INSTALLPATH}

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -477,7 +477,7 @@ exit_code=$?
 check_exit_code ${exit_code} "${ok_msg}" "${fail_msg}"
 
 
-echo ">> Creating/updating Lmod cache on $(date) ..."
+echo ">> Creating/updating Lmod cache on $(date) (nr 1) ..."
 export LMOD_RC="${EASYBUILD_INSTALLPATH}/.lmod/lmodrc.lua"
 if [ ! -f $LMOD_RC ]; then
     python3 $TOPDIR/create_lmodrc.py ${EASYBUILD_INSTALLPATH}


### PR DESCRIPTION
- We can merge the branch `nessi.no-2022.11-lmod-cache-update` into `nessi.no-2022.11-dev` with the intention to use only the latter in the future.
- If we want/need to update lmod cache, we make a new PR to `nessi.no-2022.11-dev` by increasing the running number for lmod cache updates. See line 480 in `EESSI-pilot-install-software.sh`.
- Having one branch fewer reduces the overhead to keep them in sync (also pulling in changes from EESSI/main requires a bit less effort).