### PR TITLE
prune easystack file and remove one --from-pr

### DIFF
--- a/check_missing_installations.sh
+++ b/check_missing_installations.sh
@@ -26,7 +26,9 @@ fail_msg="On no, some installations are still missing, how did that happen?!"
 eb_missing_out=$LOCAL_TMPDIR/eb_missing.out
 # we need to use --from-pr to pull in some easyconfigs that are not available in EasyBuild version being used
 # PR #16531: Nextflow-22.10.1.eb
-${EB:-eb} --from-pr 16531 --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
+# ${EB:-eb} --from-pr 16531 --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
+# PR 16531 not needed since we use EB v4.7.0
+${EB:-eb} --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
 
 # the above assesses the installed software for each easyconfig provided in
 # the easystack file and then print messages such as

--- a/eessi-2022.11.yml
+++ b/eessi-2022.11.yml
@@ -1,6 +1,5 @@
 easyconfigs:
   - EasyBuild-4.6.2.eb
-  - EasyBuild-4.7.0.eb
   - Java-11.eb
   - Java-17.eb
   - GCC-9.3.0.eb


### PR DESCRIPTION
Just run a quick test if all easyconfigs are actually installed. Until now the check implemented by `check_missing_installations.sh` and particularly the file `eessi-2022.11.yml` was broken.