### PR TITLE
install GCC/10.3.0 & fix easystack file

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -476,7 +476,7 @@ export GCC_EC="GCC-10.3.0.eb"
 echo ">> Starting slow with ${GCC_EC}..."
 ok_msg="${GCC_EC} installed, yippy! Off to a good start..."
 fail_msg="Installation of ${GCC_EC} failed!"
-$EB --robot  GCCcore-10.3.0.eb
+$EB --robot ${GCC_EC}
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 # install Java 17

--- a/check_missing_installations.sh
+++ b/check_missing_installations.sh
@@ -26,7 +26,9 @@ fail_msg="On no, some installations are still missing, how did that happen?!"
 eb_missing_out=$LOCAL_TMPDIR/eb_missing.out
 # we need to use --from-pr to pull in some easyconfigs that are not available in EasyBuild version being used
 # PR #16531: Nextflow-22.10.1.eb
-${EB:-eb} --from-pr 16531 --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
+# ${EB:-eb} --from-pr 16531 --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
+# PR 16531 not needed since we use EB v4.7.0
+${EB:-eb} --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
 
 # the above assesses the installed software for each easyconfig provided in
 # the easystack file and then print messages such as

--- a/check_missing_installations.sh
+++ b/check_missing_installations.sh
@@ -28,7 +28,9 @@ eb_missing_out=$LOCAL_TMPDIR/eb_missing.out
 # PR #16531: Nextflow-22.10.1.eb
 # ${EB:-eb} --from-pr 16531 --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
 # PR 16531 not needed since we use EB v4.7.0
-${EB:-eb} --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
+# this, however, breaks the GHA https://github.com/NorESSI/software-layer/blob/main/.github/workflows/test_eessi.yml
+# because it uses the EESSI pilot which only provides EB 4.5.1, so adding it back
+${EB:-eb} --from-pr 16531 --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
 
 # the above assesses the installed software for each easyconfig provided in
 # the easystack file and then print messages such as

--- a/eessi-2022.11.yml
+++ b/eessi-2022.11.yml
@@ -1,6 +1,5 @@
 easyconfigs:
   - EasyBuild-4.6.2.eb
-  - EasyBuild-4.7.0.eb
   - Java-11.eb
   - Java-17.eb
   - GCC-9.3.0.eb


### PR DESCRIPTION
This is in some sense a clean-up PR. It

- adds GCC/10.3.0 (only GCCcore/10.3.0 was installed before)
- ~removes one unnecessary `--from-pr` (from `check_missing_installations.sh`)~ breaks one GHA test, so added it back
- removes `EasyBuild-4.7.0.eb` from `eessi-2022.11.yml` because EasyBuild does not provide the easyconfig for its own version