### PR TITLE
ensure that dev branch is healthy 

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -464,18 +464,6 @@ $EB ImageMagick-7.0.11-14-GCCcore-10.3.0.eb --robot
 #cat $($EB --last-log)
 #check_exit_code $exit_code "${ok_msg}" "${fail_msg}"
 
-# add latest EasyBuild to stack
-echo ">> Adding latest EasyBuild to stack..."
-ok_msg="Latest EasyBuild got installed ... great!"
-fail_msg="Installation of latest EasyBuild failed! Disappointed."
-if [[ ${EESSI_CVMFS_REPO} == /cvmfs/pilot.eessi-hpc.org ]]; then
-    $EB --from-pr 14545 --include-easyblocks-from-pr 2805 --robot --install-latest-eb-release
-else
-    $EB --robot --install-latest-eb-release
-fi
-exit_code=$?
-check_exit_code ${exit_code} "${ok_msg}" "${fail_msg}"
-
 
 echo ">> Creating/updating Lmod cache on $(date) (nr 1) ..."
 export LMOD_RC="${EASYBUILD_INSTALLPATH}/.lmod/lmodrc.lua"

--- a/check_missing_installations.sh
+++ b/check_missing_installations.sh
@@ -27,7 +27,10 @@ eb_missing_out=$LOCAL_TMPDIR/eb_missing.out
 # we need to use --from-pr to pull in some easyconfigs that are not available in EasyBuild version being used
 # PR #16531: Nextflow-22.10.1.eb
 # ${EB:-eb} --from-pr 16531 --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
-${EB:-eb} --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
+# PR 16531 not needed since we use EB v4.7.0
+# this, however, breaks the GHA https://github.com/NorESSI/software-layer/blob/main/.github/workflows/test_eessi.yml
+# because it uses the EESSI pilot which only provides EB 4.5.1, so adding it back
+${EB:-eb} --from-pr 16531 --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
 
 # the above assesses the installed software for each easyconfig provided in
 # the easystack file and then print messages such as

--- a/check_missing_installations.sh
+++ b/check_missing_installations.sh
@@ -26,7 +26,8 @@ fail_msg="On no, some installations are still missing, how did that happen?!"
 eb_missing_out=$LOCAL_TMPDIR/eb_missing.out
 # we need to use --from-pr to pull in some easyconfigs that are not available in EasyBuild version being used
 # PR #16531: Nextflow-22.10.1.eb
-${EB:-eb} --from-pr 16531 --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
+# ${EB:-eb} --from-pr 16531 --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
+${EB:-eb} --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
 
 # the above assesses the installed software for each easyconfig provided in
 # the easystack file and then print messages such as

--- a/eessi-2022.11.yml
+++ b/eessi-2022.11.yml
@@ -1,5 +1,5 @@
 easyconfigs:
-  - EasyBuild-4.7.0.eb
+  - EasyBuild-4.6.2.eb
   - CMake-3.20.1-GCCcore-10.3.0.eb
   - Python-3.9.5-GCCcore-10.3.0.eb
   - OpenMPI-4.1.1-GCC-10.3.0.eb


### PR DESCRIPTION
Replacement PR for #76 so we can avoid large tarballs for `generic` architectures are uploaded.
- removed EB 4.7.0 from easystack file, added EB 4.6.2
- removed additional installation of latest EB release which may change over time (as just happened on March 20)