### PR TITLE
Add Qt/5.14.1 with GCC/9.3.0 to NESSI/2022.11 (generic only)

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -290,7 +290,7 @@ check_exit_code $? "${ok_msg}" "${fail_msg}"
 echo ">> Installing Qt5..."
 ok_msg="Qt5 installed, phieuw, that was a big one!"
 fail_msg="Installation of Qt5 failed, that's frustrating..."
-$EB Qt5-5.14.1-GCCcore-9.3.0.eb --robot --disable-cleanup-tmpdir
+$EB Qt5-5.14.1-GCCcore-9.3.0.eb --robot
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 # skip test step when installing SciPy-bundle on aarch64,

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -283,11 +283,11 @@ fail_msg="Installation of Perl failed, this never happens..."
 $EB Perl-5.30.2-GCCcore-9.3.0.eb --robot
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
-#echo ">> Installing Qt5..."
-#ok_msg="Qt5 installed, phieuw, that was a big one!"
-#fail_msg="Installation of Qt5 failed, that's frustrating..."
-#$EB Qt5-5.14.1-GCCcore-9.3.0.eb --robot --disable-cleanup-tmpdir
-#check_exit_code $? "${ok_msg}" "${fail_msg}"
+echo ">> Installing Qt5..."
+ok_msg="Qt5 installed, phieuw, that was a big one!"
+fail_msg="Installation of Qt5 failed, that's frustrating..."
+$EB Qt5-5.14.1-GCCcore-9.3.0.eb --robot --disable-cleanup-tmpdir
+check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 # skip test step when installing SciPy-bundle on aarch64,
 # to dance around problem with broken numpy tests;

--- a/eessi-2022.11.yml
+++ b/eessi-2022.11.yml
@@ -14,3 +14,4 @@ easyconfigs:
   - Python-3.9.5-GCCcore-10.3.0.eb
   - Perl-5.30.2-GCCcore-9.3.0.eb
   - ImageMagick-7.0.11-14-GCCcore-10.3.0.eb
+  - Qt5-5.14.1-GCCcore-9.3.0.eb


### PR DESCRIPTION
Trying to rebuild Qt/5.14.1 with GCC/9.3.0 to NESSI/2022.11 for generic 