### PR TITLE
Add SciPy-bundle/2020.03 with GCC/9.3.0 to NESSI/2022.11 (generic only)

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -292,16 +292,16 @@ check_exit_code $? "${ok_msg}" "${fail_msg}"
 # skip test step when installing SciPy-bundle on aarch64,
 # to dance around problem with broken numpy tests;
 # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/11959
-#echo ">> Installing SciPy-bundle"
-#ok_msg="SciPy-bundle installed, yihaa!"
-#fail_msg="SciPy-bundle installation failed, bummer..."
-#SCIPY_EC=SciPy-bundle-2020.03-foss-2020a-Python-3.8.2.eb
-#if [[ "$(uname -m)" == "aarch64" ]]; then
-#  $EB $SCIPY_EC --robot --skip-test-step
-#else
-#  $EB $SCIPY_EC --robot
-#fi
-#check_exit_code $? "${ok_msg}" "${fail_msg}"
+echo ">> Installing SciPy-bundle"
+ok_msg="SciPy-bundle installed, yihaa!"
+fail_msg="SciPy-bundle installation failed, bummer..."
+SCIPY_EC=SciPy-bundle-2020.03-foss-2020a-Python-3.8.2.eb
+if [[ "$(uname -m)" == "aarch64" ]]; then
+  $EB $SCIPY_EC --robot --skip-test-step
+else
+  $EB $SCIPY_EC --robot
+fi
+check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 #echo ">> Installing GROMACS..."
 #ok_msg="GROMACS installed, wow!"

--- a/eessi-2022.11.yml
+++ b/eessi-2022.11.yml
@@ -14,3 +14,4 @@ easyconfigs:
   - Python-3.9.5-GCCcore-10.3.0.eb
   - Perl-5.30.2-GCCcore-9.3.0.eb
   - ImageMagick-7.0.11-14-GCCcore-10.3.0.eb
+  - SciPy-bundle-2020.03-foss-2020a-Python-3.8.2.eb


### PR DESCRIPTION
Rebuilding SciPy-bundle/2020.03 with GCC/9.3.0 to NESSI/2022.11 for generic