### PR TITLE
Add TensorFlow/2.3.1 with GCC/9.3.0 to NESSI/2022.11

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -335,11 +335,11 @@ check_exit_code $? "${ok_msg}" "${fail_msg}"
 #$EB R-bundle-Bioconductor-3.11-foss-2020a-R-4.0.0.eb --robot
 #check_exit_code $? "${ok_msg}" "${fail_msg}"
 
-#echo ">> Installing TensorFlow 2.3.1..."
-#ok_msg="TensorFlow 2.3.1 installed, w00!"
-#fail_msg="Installation of TensorFlow failed, why am I not surprised..."
-#$EB TensorFlow-2.3.1-foss-2020a-Python-3.8.2.eb --robot --include-easyblocks-from-pr 2218
-#check_exit_code $? "${ok_msg}" "${fail_msg}"
+echo ">> Installing TensorFlow 2.3.1..."
+ok_msg="TensorFlow 2.3.1 installed, w00!"
+fail_msg="Installation of TensorFlow failed, why am I not surprised..."
+$EB TensorFlow-2.3.1-foss-2020a-Python-3.8.2.eb --robot --include-easyblocks-from-pr 2218
+check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 #echo ">> Installing Horovod 0.21.3..."
 #ok_msg="Horovod installed! Go do some parallel training!"

--- a/eessi-2022.11.yml
+++ b/eessi-2022.11.yml
@@ -22,3 +22,4 @@ easyconfigs:
   - SciPy-bundle-2020.03-foss-2020a-Python-3.8.2.eb
   - Spark-3.1.1-foss-2020a-Python-3.8.2.eb
   - WRF-3.9.1.1-foss-2020a-dmpar.eb
+  - TensorFlow-2.3.1-foss-2020a-Python-3.8.2.eb


### PR DESCRIPTION
Trying to add TensorFlow/2.3.1-Python-3.8.2 with GCC/9.3.0 to NESSI/2022.11 