### PR TITLE
Add QuantumESPRESSO/6.6 with GCC/9.3.0 to NESSI/2022.11

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -315,13 +315,13 @@ check_exit_code $? "${ok_msg}" "${fail_msg}"
 #$EB OpenFOAM-8-foss-2020a.eb OpenFOAM-v2006-foss-2020a.eb --robot
 #check_exit_code $? "${ok_msg}" "${fail_msg}"
 
-#if [ ! "${EESSI_CPU_FAMILY}" = "ppc64le" ]; then
-#    echo ">> Installing QuantumESPRESSO..."
-#    ok_msg="QuantumESPRESSO installed, let's go quantum!"
-#    fail_msg="Installation of QuantumESPRESSO failed, did somebody observe it?!"
-#    $EB QuantumESPRESSO-6.6-foss-2020a.eb --robot
-#    check_exit_code $? "${ok_msg}" "${fail_msg}"
-#fi
+if [ ! "${EESSI_CPU_FAMILY}" = "ppc64le" ]; then
+    echo ">> Installing QuantumESPRESSO..."
+    ok_msg="QuantumESPRESSO installed, let's go quantum!"
+    fail_msg="Installation of QuantumESPRESSO failed, did somebody observe it?!"
+    $EB QuantumESPRESSO-6.6-foss-2020a.eb --robot
+    check_exit_code $? "${ok_msg}" "${fail_msg}"
+fi
 
 echo ">> Installing R 4.0.0 (better be patient)..."
 ok_msg="R installed, wow!"

--- a/eessi-2022.11.yml
+++ b/eessi-2022.11.yml
@@ -22,3 +22,4 @@ easyconfigs:
   - SciPy-bundle-2020.03-foss-2020a-Python-3.8.2.eb
   - Spark-3.1.1-foss-2020a-Python-3.8.2.eb
   - WRF-3.9.1.1-foss-2020a-dmpar.eb
+  - QuantumESPRESSO-6.6-foss-2020a.eb


### PR DESCRIPTION
Trying to add QuantumESPRESSO/6.6 with GCC/9.3.0 to NESSI/2022.11