### PR TITLE
add Python with GCC/10.30.0 to NESSI/2023.04

### DIFF
--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -8,3 +8,10 @@ easyconfigs:
   - OpenSSL-1.1.eb:
       options:
         include-easyblocks-from-pr: 2922
+  - CMake-3.20.1-GCCcore-10.3.0.eb:
+      options:
+        include-easyblocks-from-pr: 2248
+  - Perl-5.32.1-GCCcore-10.3.0.eb
+  - Rust-1.52.1-GCCcore-10.3.0.eb
+  - Python-3.9.5-GCCcore-10.3.0.eb
+  - OpenMPI-4.1.1-GCC-10.3.0.eb


### PR DESCRIPTION
After #105 it has been reduced to Python/3.9.5 only (and indirectly Rust/1.60.0 via #106).

All additions made via easystack file:

```yaml
  - CMake-3.20.1-GCCcore-10.3.0.eb:
      options:
        include-easyblocks-from-pr: 2248
  - Perl-5.32.1-GCCcore-10.3.0.eb
  - Rust-1.52.1-GCCcore-10.3.0.eb
  - Python-3.9.5-GCCcore-10.3.0.eb
  - OpenMPI-4.1.1-GCC-10.3.0.eb
```

For Python/3.9.5 only, the following packages are missing:

- UnZip-6.0-GCCcore-10.3.0.eb (module: UnZip/6.0-GCCcore-10.3.0)
- GMP-6.2.1-GCCcore-10.3.0.eb (module: GMP/6.2.1-GCCcore-10.3.0)
- libffi-3.3-GCCcore-10.3.0.eb (module: libffi/3.3-GCCcore-10.3.0)
- Tcl-8.6.11-GCCcore-10.3.0.eb (module: Tcl/8.6.11-GCCcore-10.3.0)
- SQLite-3.35.4-GCCcore-10.3.0.eb (module: SQLite/3.35.4-GCCcore-10.3.0)
- Python-3.9.5-GCCcore-10.3.0-bare.eb (module: Python/3.9.5-GCCcore-10.3.0-bare)
- Rust-1.60.0-GCCcore-10.3.0.eb (module: Rust/1.60.0-GCCcore-10.3.0)
- git-2.32.0-GCCcore-10.3.0-nodocs.eb (module: git/2.32.0-GCCcore-10.3.0-nodocs)
- Python-3.9.5-GCCcore-10.3.0.eb (module: Python/3.9.5-GCCcore-10.3.0)