### PR TITLE
improve `check_missing_installations.sh`

### DIFF
--- a/check_missing_installations.sh
+++ b/check_missing_installations.sh
@@ -3,6 +3,7 @@
 # Script to check for missing installations in EESSI pilot software stack (version 2021.12)
 #
 # author: Kenneth Hoste (@boegel)
+# author: Thomas Roeblitz (@trz42)
 #
 # license: GPLv2
 #
@@ -21,16 +22,19 @@ source $TOPDIR/scripts/utils.sh
 source $TOPDIR/configure_easybuild
 
 echo ">> Checking for missing installations in ${EASYBUILD_INSTALLPATH}..."
-ok_msg="No missing installations, party time!"
-fail_msg="On no, some installations are still missing, how did that happen?!"
 eb_missing_out=$LOCAL_TMPDIR/eb_missing.out
 # we need to use --from-pr to pull in some easyconfigs that are not available in EasyBuild version being used
 # PR #16531: Nextflow-22.10.1.eb
-# ${EB:-eb} --from-pr 16531 --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
+# ${EB:-eb} --from-pr 16531 --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing 2>&1 | tee ${eb_missing_out}
 # PR 16531 not needed since we use EB v4.7.0
 # this, however, breaks the GHA https://github.com/NorESSI/software-layer/blob/main/.github/workflows/test_eessi.yml
 # because it uses the EESSI pilot which only provides EB 4.5.1, so adding it back
-${EB:-eb} --from-pr 16531 --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing | tee ${eb_missing_out}
+${EB:-eb} --from-pr 16531 --easystack eessi-${EESSI_PILOT_VERSION}.yml --experimental --missing 2>&1 | tee ${eb_missing_out}
+exit_code=${PIPESTATUS[0]}
+
+ok_msg="Command 'eb --missing ...' succeeded, analysing output..."
+fail_msg="Command 'eb --missing ...' failed, check log '${eb_missing_out}'"
+check_exit_code ${exit_code} "${ok_msg}" "${fail_msg}"
 
 # the above assesses the installed software for each easyconfig provided in
 # the easystack file and then print messages such as
@@ -41,8 +45,11 @@ ${EB:-eb} --from-pr 16531 --easystack eessi-${EESSI_PILOT_VERSION}.yml --experim
 # output does not contain any line with ` required modules missing:`
 
 grep " required modules missing:" ${eb_missing_out} > /dev/null
+exit_code=$?
 
 # if grep returns 1 (` required modules missing:` was NOT found), we set
 # MODULES_MISSING to 0, otherwise (it was found or another error) we set it to 1
-[[ $? -eq 1 ]] && MODULES_MISSING=0 || MODULES_MISSING=1
+[[ ${exit_code} -eq 1 ]] && MODULES_MISSING=0 || MODULES_MISSING=1
+ok_msg="No missing installations, party time!"
+fail_msg="On no, some installations are still missing, how did that happen?!"
 check_exit_code ${MODULES_MISSING} "${ok_msg}" "${fail_msg}"


### PR DESCRIPTION
Essentially the same as https://github.com/EESSI/software-layer/pull/244

- redirects `stderr` into output file
- captures exit code of `eb` (first command in pipe, captured via `${PIPESTATUS[0]}`)
- analyses exit code of `eb`
- stores exit code of `grep` in `exit_code`

Can be tested as follows
1. Set pilot version via `export EESSI_PILOT_VERSION=YYYY.MM`
2. Test case that easystack file does not exist:
   - Set version such that no `eessi-${EESSI_PILOT_VERSION}.yml` exists in the current directory.
   - Then simply run `check_missing_installations.sh`. It should report an error and ask to check a log file.
3. Test case that easystack file contains spelling mistakes:
   - Create simple easystack file named `eessi-${EESSI_PILOT_VERSION}.yml` in the current directory with content such as
     ```yaml
     easyconfigs:
       - GCC-9.3.0.eb:
           options:
             option-that-does-not-exist
     ```
   - Then simply run `check_missing_installations.sh`. It should report an error and ask to check a log file.