### PR TITLE
add FFTW/3.3.9 with gompi/2021a to NESSI/2023.04

### DIFF
--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -1,5 +1,6 @@
 easyconfigs:
 #  - GCC-9.3.0.eb
+  - FFTW-3.3.9-gompi-2021a.eb
   - GCC-10.3.0.eb:
       options:
         include-easyblocks-from-pr: 2921


### PR DESCRIPTION
Part of foss/2021a toolchain (see https://docs.easybuild.io/common-toolchains/#common_toolchains_overview_foss).

Missing packages:
-  gompi-2021a.eb (module: gompi/2021a)
- FFTW-3.3.9-gompi-2021a.eb (module: FFTW/3.3.9-gompi-2021a)