### PR TITLE
Adding ScaLAPACK/2.1.0 with gompi/2021a to NESSI/2023.04

### DIFF
--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -17,3 +17,4 @@ easyconfigs:
   - OpenBLAS-0.3.15-GCC-10.3.0.eb:
       options:
         from-pr: 17924
+  - ScaLAPACK-2.1.0-gompi-2021a-fb.eb

--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -18,3 +18,4 @@ easyconfigs:
       options:
         from-pr: 17924
   - ScaLAPACK-2.1.0-gompi-2021a-fb.eb
+  - FFTW-3.3.9-gompi-2021a.eb


### PR DESCRIPTION
Adding ScaLAPACK/2.1.0 with gompi/2021a which has  FlexiBLAS as dependency + FFTW-3.3.9 with gompi/2021a  to NESSI/2023.04