### PR TITLE
Adding Qt5/5.15.2 with GCCcore/10.3.0.eb to NESSI/2023.04

### DIFF
--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -17,3 +17,4 @@ easyconfigs:
   - OpenBLAS-0.3.15-GCC-10.3.0.eb:
       options:
         from-pr: 17924
+  - Qt5-5.15.2-GCCcore-10.3.0.eb


### PR DESCRIPTION
Trying to add Qt5/5.15.2 with GCCcore/10.3.0.eb to NESSI/2023.04