### PR TITLE
Adding Python-2.7.18-GCCcore-10.3.0-bare to NESSI/2023.04 as trial

### DIFF
--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -17,3 +17,4 @@ easyconfigs:
   - OpenBLAS-0.3.15-GCC-10.3.0.eb:
       options:
         from-pr: 17924
+  - Python-2.7.18-GCCcore-10.3.0-bare.eb


### PR DESCRIPTION
Adding Python-2.7.18-GCCcore-10.3.0-bare to NESSI/2023.04 as trial to troubleshoot the building of Qt5