### PR TITLE
add GCC/11.3.0 to NESSI/2023.04

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -6,7 +6,7 @@ import re
 from easybuild.easyblocks.generic.configuremake import obtain_config_guess
 from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.config import build_option, update_build_option
-from easybuild.tools.filetools import copy_file, which
+from easybuild.tools.filetools import apply_regex_substitutions, copy_file, which
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import AARCH64, POWER, X86_64, get_cpu_architecture, get_cpu_features
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
@@ -112,6 +112,17 @@ def gcc_postprepare(self, *args, **kwargs):
             prefix_wrapper = os.path.join(wrapper_dir, cmd_prefix + cmd)
             copy_file(wrapper, prefix_wrapper)
             self.log.info("Path to %s wrapper with '%s' prefix: %s" % (cmd, cmd_prefix, which(prefix_wrapper)))
+
+            # we need to tweak the copied wrapper script, so that:
+            regex_subs = [
+                # - CMD in the script is set to the command name without prefix, because EasyBuild's rpath_args.py
+                #   script that is used by the wrapper script only checks for 'ld', 'ld.gold', etc.
+                #   when checking whether or not to use -Wl
+                ('^CMD=.*', 'CMD=%s' % cmd),
+                # - the path to the correct actual binary is logged and called
+                ('/%s ' % cmd, '/%s ' % (cmd_prefix + cmd)),
+            ]
+            apply_regex_substitutions(prefix_wrapper, regex_subs)
     else:
         raise EasyBuildError("GCCcore-specific hook triggered for non-GCCcore easyconfig?!")
 

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -3,8 +3,11 @@
 import os
 import re
 
+from easybuild.easyblocks.generic.configuremake import obtain_config_guess
 from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.config import build_option, update_build_option
+from easybuild.tools.filetools import copy_file, which
+from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import AARCH64, POWER, X86_64, get_cpu_architecture, get_cpu_features
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 
@@ -93,6 +96,25 @@ def pre_prepare_hook(self, *args, **kwargs):
                   mpi_family, rpath_override_dirs)
 
 
+def gcc_postprepare(self, *args, **kwargs):
+    """
+    Post-configure hook for GCCcore:
+    - copy RPATH wrapper script for linker commands to also have a wrapper in place with system type prefix like 'x86_64-pc-linux-gnu'
+    """
+    if self.name == 'GCCcore':
+        config_guess = obtain_config_guess()
+        system_type, _ = run_cmd(config_guess, log_all=True)
+        cmd_prefix = '%s-' % system_type.strip()
+        for cmd in ('ld', 'ld.gold', 'ld.bfd'):
+            wrapper = which(cmd)
+            self.log.info("Path to %s wrapper: %s" % (cmd, wrapper))
+            wrapper_dir = os.path.dirname(wrapper)
+            prefix_wrapper = os.path.join(wrapper_dir, cmd_prefix + cmd)
+            copy_file(wrapper, prefix_wrapper)
+            self.log.info("Path to %s wrapper with '%s' prefix: %s" % (cmd, cmd_prefix, which(prefix_wrapper)))
+    else:
+        raise EasyBuildError("GCCcore-specific hook triggered for non-GCCcore easyconfig?!")
+
 def post_prepare_hook(self, *args, **kwargs):
     """Main post-prepare hook: trigger custom functions."""
 
@@ -101,6 +123,9 @@ def post_prepare_hook(self, *args, **kwargs):
         update_build_option('rpath_override_dirs', getattr(self, EESSI_RPATH_OVERRIDE_ATTR))
         print_msg("Resetting rpath_override_dirs to original value: %s", getattr(self, EESSI_RPATH_OVERRIDE_ATTR))
         delattr(self, EESSI_RPATH_OVERRIDE_ATTR)
+
+    if self.name in POST_PREPARE_HOOKS:
+        POST_PREPARE_HOOKS[self.name](self, *args, **kwargs)
 
 
 def cgal_toolchainopts_precise(ec, eprefix):
@@ -218,6 +243,10 @@ PARSE_HOOKS = {
     'CGAL': cgal_toolchainopts_precise,
     'fontconfig': fontconfig_add_fonts,
     'UCX': ucx_eprefix,
+}
+
+POST_PREPARE_HOOKS = {
+    'GCCcore': gcc_postprepare,
 }
 
 PRE_CONFIGURE_HOOKS = {

--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -4,7 +4,11 @@ easyconfigs:
       options:
         include-easyblocks-from-pr: 2921
 #  - GCC-11.3.0.eb
-#  - GCC-12.2.0.eb
+#      options:
+#        include-easyblocks-from-pr: 2921
+  - GCC-12.2.0.eb:
+      options:
+        include-easyblocks-from-pr: 2921
   - OpenSSL-1.1.eb:
       options:
         include-easyblocks-from-pr: 2922

--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -3,9 +3,9 @@ easyconfigs:
   - GCC-10.3.0.eb:
       options:
         include-easyblocks-from-pr: 2921
+# use Bart Oldeman's update to PR#2921, see https://github.com/trz42/easybuild-easyblocks/pull/1
   - GCC-11.3.0.eb
       options:
-# use Bart Oldemann's update to PR#2921, see https://github.com/trz42/easybuild-easyblocks/pull/1
         include-easyblocks-from-pr: 1
         pr-target-account: trz42
 #  - GCC-12.2.0.eb:

--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -6,7 +6,7 @@ easyconfigs:
 # use Bart Oldeman's update to PR#2921, see https://github.com/trz42/easybuild-easyblocks/pull/1
   - GCC-11.3.0.eb:
       options:
-        include-easyblocks-from-pr: 1
+        include-easyblocks-from-pr: '1'
         pr-target-account: trz42
 #  - GCC-12.2.0.eb:
 #      options:

--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -4,7 +4,7 @@ easyconfigs:
       options:
         include-easyblocks-from-pr: 2921
 # use Bart Oldeman's update to PR#2921, see https://github.com/trz42/easybuild-easyblocks/pull/1
-  - GCC-11.3.0.eb
+  - GCC-11.3.0.eb:
       options:
         include-easyblocks-from-pr: 1
         pr-target-account: trz42

--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -3,12 +3,12 @@ easyconfigs:
   - GCC-10.3.0.eb:
       options:
         include-easyblocks-from-pr: 2921
-#  - GCC-11.3.0.eb
-#      options:
-#        include-easyblocks-from-pr: 2921
-  - GCC-12.2.0.eb:
+  - GCC-11.3.0.eb
       options:
         include-easyblocks-from-pr: 2921
+#  - GCC-12.2.0.eb:
+#      options:
+#        include-easyblocks-from-pr: 2921
   - OpenSSL-1.1.eb:
       options:
         include-easyblocks-from-pr: 2922

--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -5,7 +5,9 @@ easyconfigs:
         include-easyblocks-from-pr: 2921
   - GCC-11.3.0.eb
       options:
-        include-easyblocks-from-pr: 2921
+# use Bart Oldemann's update to PR#2921, see https://github.com/trz42/easybuild-easyblocks/pull/1
+        include-easyblocks-from-pr: 1
+        pr-target-account: trz42
 #  - GCC-12.2.0.eb:
 #      options:
 #        include-easyblocks-from-pr: 2921


### PR DESCRIPTION
- includes [PR#2921](https://github.com/easybuilders/easybuild-easyblocks/pull/2921) + update to it (see https://github.com/trz42/easybuild-easyblocks/pull/1)
- includes attempt to fix missing RPATH section in some binaries and libraries, see https://github.com/EESSI/software-layer/pull/251