### PR TITLE
Adding TensorFlow/2.6.0 with foss/2021a to NESSI/2023.04

### DIFF
--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -17,4 +17,6 @@ easyconfigs:
   - OpenBLAS-0.3.15-GCC-10.3.0.eb:
       options:
         from-pr: 17924
-  - TensorFlow-2.6.0-foss-2021a.eb
+  - TensorFlow-2.6.0-foss-2021a.eb:
+      options:
+        include-easyblocks-from-pr: 2218  

--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -17,3 +17,4 @@ easyconfigs:
   - OpenBLAS-0.3.15-GCC-10.3.0.eb:
       options:
         from-pr: 17924
+  - TensorFlow-2.6.0-foss-2021a.eb


### PR DESCRIPTION
Trying to adding TensorFlow/2.6.0 with foss/2021a to NESSI/2023.04