### PR TITLE
Adding QuantumESPRESSO/6.7 with foss/2021a to NESSI/2023.04

### DIFF
--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -17,3 +17,4 @@ easyconfigs:
   - OpenBLAS-0.3.15-GCC-10.3.0.eb:
       options:
         from-pr: 17924
+  - QuantumESPRESSO-6.7-foss-2021a.eb


### PR DESCRIPTION
Trying to add QuantumESPRESSO/6.7 with foss/2021a to NESSI/2023.04