### PR TITLE
Adding IPython/7.25.0-WRF/4.3 with foss/2021a to NESSI/2023.04

### DIFF
--- a/eessi-2023.04.yml
+++ b/eessi-2023.04.yml
@@ -17,3 +17,5 @@ easyconfigs:
   - OpenBLAS-0.3.15-GCC-10.3.0.eb:
       options:
         from-pr: 17924
+  - IPython-7.25.0-GCCcore-10.3.0.eb
+  - WRF-4.3-foss-2021a-dmpar.eb


### PR DESCRIPTION
Trying to add IPython/7.25.0-WRF/4.3 with foss/2021a to NESSI/2023.04