### PR TITLE
start tool chain foss/2022b for NESSI/2023.06

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -143,7 +143,7 @@ for eb_version in '4.7.2'; do
 
     echo_green "All set, let's start installing some software with EasyBuild v${eb_version} in ${EASYBUILD_INSTALLPATH}..."
 
-    for gen in '2021a'; do
+    for gen in '2021a' '2022b'; do
 
         es="eessi-${EESSI_PILOT_VERSION}-eb-${eb_version}-${gen}.yml"
 

--- a/eessi-2023.06-eb-4.7.2-2022b.yml
+++ b/eessi-2023.06-eb-4.7.2-2022b.yml
@@ -2,4 +2,7 @@ easyconfigs:
   - OpenSSL-1.1.eb:
       options:
         include-easyblocks-from-pr: 2922
+  - CMake-3.24.3-GCCcore-12.2.0.eb:
+      options:
+        include-easyblocks-from-pr: 2248
   - foss-2022b.eb

--- a/eessi-2023.06-eb-4.7.2-2022b.yml
+++ b/eessi-2023.06-eb-4.7.2-2022b.yml
@@ -1,0 +1,5 @@
+easyconfigs:
+  - OpenSSL-1.1.eb:
+      options:
+        include-easyblocks-from-pr: 2922
+  - foss-2022b.eb


### PR DESCRIPTION
- includes `OpenSSL-1.1.eb` which is already in the Stack $\Longrightarrow$ should not build it again
- a bit unclear if and how the various check scripts (`check_missing_installations.sh` and `bot/check-result.sh`) deal with two easystack files being processed