### PR TITLE
Adding CMake/3.20-Rust/1.52.1-foss/2021a to NESSI/2023.06

### DIFF
--- a/eessi-2023.06-eb-4.7.2-2021a.yml
+++ b/eessi-2023.06-eb-4.7.2-2021a.yml
@@ -3,4 +3,8 @@ easyconfigs:
       options:
         include-easyblocks-from-pr: 2922
   - GCC-10.3.0.eb
-
+  - CMake-3.20.1-GCCcore-10.3.0.eb:
+      options:
+        include-easyblocks-from-pr: 2248
+  - Rust-1.52.1-GCCcore-10.3.0.eb
+  - foss-2021a.eb


### PR DESCRIPTION
Trying to add CMake/3.20-Rust/1.52.1-foss/2021a to NESSI/2023.06