### PR TITLE
Adding QuantumESPRESSO/6.7 with foss/2021a to NESSI/2023.06

### DIFF
--- a/eessi-2023.06-eb-4.7.2-2021a.yml
+++ b/eessi-2023.06-eb-4.7.2-2021a.yml
@@ -8,3 +8,4 @@ easyconfigs:
         include-easyblocks-from-pr: 2248
   - Rust-1.52.1-GCCcore-10.3.0.eb
   - foss-2021a.eb
+  - QuantumESPRESSO-6.7-foss-2021a.eb


### PR DESCRIPTION
Trying to add QuantumESPRESSO/6.7 with foss/2021a to NESSI/2023.06