### PR TITLE
{23.06}[foss/2021b] CMake + OpenMPI + FFTW + BLIS

### DIFF
--- a/eessi-2023.06-eb-4.7.2-2021b.yml
+++ b/eessi-2023.06-eb-4.7.2-2021b.yml
@@ -1,8 +1,11 @@
 easyconfigs:
   - GCC-11.2.0
-  # - CMake-3.21.1-GCCcore-11.2.0.eb:
-  #     options:
-  #       include-easyblocks-from-pr: 2248
+  - CMake-3.21.1-GCCcore-11.2.0.eb:
+      options:
+        include-easyblocks-from-pr: 2248
+  - OpenMPI-4.1.1-GCC-11.2.0.eb
+  - FFTW-3.3.10-gompi-2021b.eb
+  - BLIS-0.8.1-GCC-11.2.0.eb
   # - CMake-3.22.1-GCCcore-11.2.0.eb:
   #     options:
   #       include-easyblocks-from-pr: 2248


### PR DESCRIPTION
Add several components of foss/2021b (not OpenBLAS and packages depending on it):

- `CMake/3.21.1` with easyblock PR 2248
- `OpenMPI/4.1.1`
- `FFTW/3.3.10`
- `BLIS/0.8.1`