### PR TITLE
{23.06}[foss/2022b] CMake + OpenMPI + FFTW.MPI + BLIS

### DIFF
--- a/eessi-2023.06-eb-4.7.2-2022b.yml
+++ b/eessi-2023.06-eb-4.7.2-2022b.yml
@@ -1,2 +1,8 @@
 easyconfigs:
   - GCC-12.2.0
+  - CMake-3.24.3-GCCcore-12.2.0.eb:
+      options:
+        include-easyblocks-from-pr: 2248
+  - BLIS-0.9.0-GCC-12.2.0.eb
+  - OpenMPI-4.1.4-GCC-12.2.0.eb
+  - FFTW.MPI-3.3.10-gompi-2022b.eb


### PR DESCRIPTION
Add several components of foss/2022a (not OpenBLAS and packages depending on it):

- `CMake/3.24.3` with easyblock PR 2248
- `BLIS/0.9.0`
- `OpenMPI/4.1.4`
- `FFTW.MPI/3.3.10`