### PR TITLE
{23.06}[foss/2022b] Python/3.10.8

### DIFF
--- a/eessi-2023.06-eb-4.7.2-2022b.yml
+++ b/eessi-2023.06-eb-4.7.2-2022b.yml
@@ -6,3 +6,4 @@ easyconfigs:
   - BLIS-0.9.0-GCC-12.2.0.eb
   - OpenMPI-4.1.4-GCC-12.2.0.eb
   - FFTW.MPI-3.3.10-gompi-2022b.eb
+  - Python-3.10.8-GCCcore-12.2.0.eb


### PR DESCRIPTION
Secondary objective is to update lmod cache for foss/2021b and foss/2022a.