### PR TITLE
{23.06}[foss/2022a] add missing packages for foss/2022a

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -164,10 +164,10 @@ def parse_hook_openblas_relax_lapack_tests_num_errors(ec, eprefix):
     if ec.name == 'OpenBLAS':
         if get_cpu_architecture() == AARCH64:
             # relax number of failed numerical LAPACK tests
-            num_errors = '302'
+            num_errors = 302
             cfg_option = 'max_failing_lapack_tests_num_errors'
             ec[cfg_option] = num_errors
-            print_msg("Set '%s = %s' in easyconfig for %s on AARCH64", cfg_option, num_errors, ec.name)
+            print_msg("Set '%s = %d' in easyconfig for %s on AARCH64", cfg_option, num_errors, ec.name)
         else:
             print_msg("Not changing option %s for %s on non-AARCH64", cfg_option, ec.name)
     else:

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -159,6 +159,21 @@ def parse_hook_fontconfig_add_fonts(ec, eprefix):
         raise EasyBuildError("fontconfig-specific hook triggered for non-fontconfig easyconfig?!")
 
 
+def parse_hook_openblas_relax_lapack_tests_num_errors(ec, eprefix):
+    """Relax number of failing numerical LAPACK tests."""
+    if ec.name == 'OpenBLAS':
+        if get_cpu_architecture() == AARCH64:
+            # relax number of failed numerical LAPACK tests
+            num_errors = '302'
+            cfg_option = 'max_failing_lapack_tests_num_errors'
+            ec[cfg_option] = num_errors
+            print_msg("Set '%s = %s' in easyconfig for %s on AARCH64", cfg_option, num_errors, ec.name)
+        else:
+            print_msg("Not changing option %s for %s on non-AARCH64", cfg_option, ec.name)
+    else:
+        raise EasyBuildError("OpenBLAS-specific hook triggered for non-OpenBLAS easyconfig?!")
+
+
 def parse_hook_ucx_eprefix(ec, eprefix):
     """Make UCX aware of compatibility layer via additional configuration options."""
     if ec.name == 'UCX':
@@ -232,6 +247,7 @@ def pre_configure_hook_wrf_aarch64(self, *args, **kwargs):
 PARSE_HOOKS = {
     'CGAL': parse_hook_cgal_toolchainopts_precise,
     'fontconfig': parse_hook_fontconfig_add_fonts,
+    'OpenBLAS': parse_hook_openblas_relax_lapack_tests_num_errors,
     'UCX': parse_hook_ucx_eprefix,
 }
 

--- a/eessi-2023.06-eb-4.7.2-2021a.yml
+++ b/eessi-2023.06-eb-4.7.2-2021a.yml
@@ -1,11 +1,13 @@
 easyconfigs:
-  - OpenSSL-1.1.eb:
-      options:
-        include-easyblocks-from-pr: 2922
+  - OpenSSL-1.1.eb
+  # - OpenSSL-1.1.eb:
+  #     options:
+  #       include-easyblocks-from-pr: 2922
   - GCC-10.3.0
-  - CMake-3.20.1-GCCcore-10.3.0.eb:
-      options:
-        include-easyblocks-from-pr: 2248
+  - CMake-3.20.1-GCCcore-10.3.0.eb
+  # - CMake-3.20.1-GCCcore-10.3.0.eb:
+  #     options:
+  #       include-easyblocks-from-pr: 2248
   - Rust-1.52.1-GCCcore-10.3.0.eb
   - foss-2021a.eb
   - QuantumESPRESSO-6.7-foss-2021a.eb

--- a/eessi-2023.06-eb-4.7.2-2021b.yml
+++ b/eessi-2023.06-eb-4.7.2-2021b.yml
@@ -1,8 +1,9 @@
 easyconfigs:
   - GCC-11.2.0
-  - CMake-3.21.1-GCCcore-11.2.0.eb:
-      options:
-        include-easyblocks-from-pr: 2248
+  - CMake-3.21.1-GCCcore-11.2.0.eb
+  # - CMake-3.21.1-GCCcore-11.2.0.eb:
+  #     options:
+  #       include-easyblocks-from-pr: 2248
   - OpenMPI-4.1.1-GCC-11.2.0.eb
   - FFTW-3.3.10-gompi-2021b.eb
   - BLIS-0.8.1-GCC-11.2.0.eb

--- a/eessi-2023.06-eb-4.7.2-2022a.yml
+++ b/eessi-2023.06-eb-4.7.2-2022a.yml
@@ -6,3 +6,4 @@ easyconfigs:
   - BLIS-0.9.0-GCC-11.3.0.eb
   - OpenMPI-4.1.4-GCC-11.3.0.eb
   - FFTW.MPI-3.3.10-gompi-2022a.eb
+  - foss-2022a.eb

--- a/eessi-2023.06-eb-4.7.2-2022a.yml
+++ b/eessi-2023.06-eb-4.7.2-2022a.yml
@@ -1,8 +1,9 @@
 easyconfigs:
   - GCC-11.3.0
-  - CMake-3.23.1-GCCcore-11.3.0.eb:
-      options:
-        include-easyblocks-from-pr: 2248
+  - CMake-3.23.1-GCCcore-11.3.0.eb
+  # - CMake-3.23.1-GCCcore-11.3.0.eb:
+  #     options:
+  #       include-easyblocks-from-pr: 2248
   - BLIS-0.9.0-GCC-11.3.0.eb
   - OpenMPI-4.1.4-GCC-11.3.0.eb
   - FFTW.MPI-3.3.10-gompi-2022a.eb

--- a/eessi-2023.06-eb-4.7.2-2022b.yml
+++ b/eessi-2023.06-eb-4.7.2-2022b.yml
@@ -1,8 +1,9 @@
 easyconfigs:
   - GCC-12.2.0
-  - CMake-3.24.3-GCCcore-12.2.0.eb:
-      options:
-        include-easyblocks-from-pr: 2248
+  - CMake-3.24.3-GCCcore-12.2.0.eb
+  # - CMake-3.24.3-GCCcore-12.2.0.eb:
+  #     options:
+  #       include-easyblocks-from-pr: 2248
   - BLIS-0.9.0-GCC-12.2.0.eb
   - OpenMPI-4.1.4-GCC-12.2.0.eb
   - FFTW.MPI-3.3.10-gompi-2022b.eb


### PR DESCRIPTION
Should build

- OpenBLAS/0.3.20
- FlexiBLAS/3.2.0
- ScaLAPACK/2.2.0