### PR TITLE
{23.06}[foss/2022b] add missing packages for foss/2022b

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -164,10 +164,10 @@ def parse_hook_openblas_relax_lapack_tests_num_errors(ec, eprefix):
     if ec.name == 'OpenBLAS':
         if get_cpu_architecture() == AARCH64:
             # relax number of failed numerical LAPACK tests
-            num_errors = '302'
+            num_errors = 302
             cfg_option = 'max_failing_lapack_tests_num_errors'
             ec[cfg_option] = num_errors
-            print_msg("Set '%s = %s' in easyconfig for %s on AARCH64", cfg_option, num_errors, ec.name)
+            print_msg("Set '%s = %d' in easyconfig for %s on AARCH64", cfg_option, num_errors, ec.name)
         else:
             print_msg("Not changing option %s for %s on non-AARCH64", cfg_option, ec.name)
     else:

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -159,6 +159,21 @@ def parse_hook_fontconfig_add_fonts(ec, eprefix):
         raise EasyBuildError("fontconfig-specific hook triggered for non-fontconfig easyconfig?!")
 
 
+def parse_hook_openblas_relax_lapack_tests_num_errors(ec, eprefix):
+    """Relax number of failing numerical LAPACK tests."""
+    if ec.name == 'OpenBLAS':
+        if get_cpu_architecture() == AARCH64:
+            # relax number of failed numerical LAPACK tests
+            num_errors = '302'
+            cfg_option = 'max_failing_lapack_tests_num_errors'
+            ec[cfg_option] = num_errors
+            print_msg("Set '%s = %s' in easyconfig for %s on AARCH64", cfg_option, num_errors, ec.name)
+        else:
+            print_msg("Not changing option %s for %s on non-AARCH64", cfg_option, ec.name)
+    else:
+        raise EasyBuildError("OpenBLAS-specific hook triggered for non-OpenBLAS easyconfig?!")
+
+
 def parse_hook_ucx_eprefix(ec, eprefix):
     """Make UCX aware of compatibility layer via additional configuration options."""
     if ec.name == 'UCX':
@@ -232,6 +247,7 @@ def pre_configure_hook_wrf_aarch64(self, *args, **kwargs):
 PARSE_HOOKS = {
     'CGAL': parse_hook_cgal_toolchainopts_precise,
     'fontconfig': parse_hook_fontconfig_add_fonts,
+    'OpenBLAS': parse_hook_openblas_relax_lapack_tests_num_errors,
     'UCX': parse_hook_ucx_eprefix,
 }
 

--- a/eessi-2023.06-eb-4.7.2-2022b.yml
+++ b/eessi-2023.06-eb-4.7.2-2022b.yml
@@ -7,3 +7,4 @@ easyconfigs:
   - OpenMPI-4.1.4-GCC-12.2.0.eb
   - FFTW.MPI-3.3.10-gompi-2022b.eb
   - Python-3.10.8-GCCcore-12.2.0.eb
+  - foss-2022b.eb


### PR DESCRIPTION
Should build

- OpenBLAS/0.3.21
- FlexiBLAS/3.2.1
- ScaLAPACK/2.2.0