### PR TITLE
{2023.06}[gompi/2021a] netCDF V4.8.0

### DIFF
--- a/eessi-2023.06-eb-4.7.2-2021a.yml
+++ b/eessi-2023.06-eb-4.7.2-2021a.yml
@@ -14,3 +14,4 @@ easyconfigs:
   - GROMACS-2021.3-foss-2021a.eb:  
         options:
           download-timeout: 1000
+  - netCDF-4.8.0-gompi-2021a.eb 


### PR DESCRIPTION
Trying to add netCDF-4.8.0-gompi-2021a