### PR TITLE
{2023.06}[foss/2021a] BAGEL V1.2.2

### DIFF
--- a/eessi-2023.06-eb-4.7.2-2021a.yml
+++ b/eessi-2023.06-eb-4.7.2-2021a.yml
@@ -15,3 +15,6 @@ easyconfigs:
         options:
           download-timeout: 1000
   - libGLU-9.0.1-GCCcore-10.3.0.eb
+  - BAGEL-1.2.2-foss-2021a.eb:
+        options:
+          from-pr: 18446


### PR DESCRIPTION
BAGEL was initially built using intel toolchain, modifications are done to the original easyconfig file in the attempt to build the software using foss/2021a toolchain.

The patch ***BAGEL-1.2.2_serialization.patch*** has been added with the reference to : [https://github.com/qsimulate-open/bagel/commit/4c0ab21158dbe1ef4373cce5735cc1392146386c](url)