### PR TITLE
{2023.06}[intel/2022a]

### DIFF
--- a/eessi-2023.06-eb-4.7.2-2022a.yml
+++ b/eessi-2023.06-eb-4.7.2-2022a.yml
@@ -9,4 +9,6 @@ easyconfigs:
   - FFTW.MPI-3.3.10-gompi-2022a.eb
   - foss-2022a.eb
   - Python-3.10.4-GCCcore-11.3.0.eb
-  - intel-compilers-2022.1.0.eb
+  - intel-compilers-2022.1.0.eb:
+        options:   
+          accept-eula-for: Intel-oneAPI

--- a/eessi-2023.06-eb-4.7.2-2022a.yml
+++ b/eessi-2023.06-eb-4.7.2-2022a.yml
@@ -9,3 +9,4 @@ easyconfigs:
   - FFTW.MPI-3.3.10-gompi-2022a.eb
   - foss-2022a.eb
   - Python-3.10.4-GCCcore-11.3.0.eb
+  - intel-compilers-2022.1.0.eb


### PR DESCRIPTION
Trying to build intel compiler 2022.1.0 as a first step in building the whole tool-chain.