### PR TITLE
{2023.06}[all toolchains] remove cURL from filter-deps and rebuild git

### DIFF
--- a/configure_easybuild
+++ b/configure_easybuild
@@ -26,7 +26,7 @@ fi
 # note: filtering Bison may break some installations, like Qt5 (see https://github.com/EESSI/software-layer/issues/49)
 # filtering pkg-config breaks R-bundle-Bioconductor installation (see also https://github.com/easybuilders/easybuild-easyconfigs/pull/11104)
 # problems occur when filtering pkg-config with gnuplot too (picks up Lua 5.1 from $EPREFIX rather than from Lua 5.3 dependency)
-DEPS_TO_FILTER=Autoconf,Automake,Autotools,binutils,bzip2,cURL,DBus,flex,gettext,gperf,help2man,intltool,libreadline,libtool,Lua,M4,makeinfo,ncurses,util-linux,XZ,zlib
+DEPS_TO_FILTER=Autoconf,Automake,Autotools,binutils,bzip2,DBus,flex,gettext,gperf,help2man,intltool,libreadline,libtool,Lua,M4,makeinfo,ncurses,util-linux,XZ,zlib
 # For aarch64 we need to also filter out Yasm.
 # See https://github.com/easybuilders/easybuild-easyconfigs/issues/11190
 if [[ "$EESSI_CPU_FAMILY" == "aarch64" ]]; then

--- a/eessi-2023.06-eb-4.7.2-2021a.yml
+++ b/eessi-2023.06-eb-4.7.2-2021a.yml
@@ -3,6 +3,7 @@ easyconfigs:
   # - OpenSSL-1.1.eb:
   #     options:
   #       include-easyblocks-from-pr: 2922
+  - git-2.32.0-GCCcore-10.3.0-nodocs.eb
   - GCC-10.3.0
   - CMake-3.20.1-GCCcore-10.3.0.eb
   # - CMake-3.20.1-GCCcore-10.3.0.eb:

--- a/eessi-2023.06-eb-4.7.2-2021b.yml
+++ b/eessi-2023.06-eb-4.7.2-2021b.yml
@@ -1,5 +1,6 @@
 easyconfigs:
   - GCC-11.2.0
+  - git-2.33.1-GCCcore-11.2.0-nodocs.eb
   - CMake-3.21.1-GCCcore-11.2.0.eb
   # - CMake-3.21.1-GCCcore-11.2.0.eb:
   #     options:

--- a/eessi-2023.06-eb-4.7.2-2022a.yml
+++ b/eessi-2023.06-eb-4.7.2-2022a.yml
@@ -1,5 +1,6 @@
 easyconfigs:
   - GCC-11.3.0
+  - git-2.36.0-GCCcore-11.3.0-nodocs.eb
   - CMake-3.23.1-GCCcore-11.3.0.eb
   # - CMake-3.23.1-GCCcore-11.3.0.eb:
   #     options:

--- a/eessi-2023.06-eb-4.7.2-2022b.yml
+++ b/eessi-2023.06-eb-4.7.2-2022b.yml
@@ -1,5 +1,6 @@
 easyconfigs:
   - GCC-12.2.0
+  - git-2.38.1-GCCcore-12.2.0-nodocs.eb
   - CMake-3.24.3-GCCcore-12.2.0.eb
   # - CMake-3.24.3-GCCcore-12.2.0.eb:
   #     options:


### PR DESCRIPTION
Removes `cURL` from filter-deps in `configure_easybuild` and rebuilds git for `foss/2021a`, `foss/2021b`, `foss/2022a` and `foss/2022b`:

- `git-2.32.0-GCCcore-10.3.0-nodocs.eb`
- `git-2.33.1-GCCcore-11.2.0-nodocs.eb`
- `git-2.36.0-GCCcore-11.3.0-nodocs.eb`
- `git-2.38.1-GCCcore-12.2.0-nodocs.eb`

Requires removal of module files and software directories on Stratum-0 before starting the building.