### PR TITLE
{23.06}[all toolchains] rebuild CMake

### DIFF
--- a/eessi-2023.06-eb-4.7.2-2021a.yml
+++ b/eessi-2023.06-eb-4.7.2-2021a.yml
@@ -5,10 +5,10 @@ easyconfigs:
   #       include-easyblocks-from-pr: 2922
   - git-2.32.0-GCCcore-10.3.0-nodocs.eb
   - GCC-10.3.0
-  - CMake-3.20.1-GCCcore-10.3.0.eb
-  # - CMake-3.20.1-GCCcore-10.3.0.eb:
-  #     options:
-  #       include-easyblocks-from-pr: 2248
+  # - CMake-3.20.1-GCCcore-10.3.0.eb
+  - CMake-3.20.1-GCCcore-10.3.0.eb:
+      options:
+        include-easyblocks-from-pr: 2248
   - Rust-1.52.1-GCCcore-10.3.0.eb
   - foss-2021a.eb
   - QuantumESPRESSO-6.7-foss-2021a.eb

--- a/eessi-2023.06-eb-4.7.2-2021b.yml
+++ b/eessi-2023.06-eb-4.7.2-2021b.yml
@@ -1,10 +1,10 @@
 easyconfigs:
   - GCC-11.2.0
   - git-2.33.1-GCCcore-11.2.0-nodocs.eb
-  - CMake-3.21.1-GCCcore-11.2.0.eb
-  # - CMake-3.21.1-GCCcore-11.2.0.eb:
-  #     options:
-  #       include-easyblocks-from-pr: 2248
+  # - CMake-3.21.1-GCCcore-11.2.0.eb
+  - CMake-3.21.1-GCCcore-11.2.0.eb:
+      options:
+        include-easyblocks-from-pr: 2248
   - OpenMPI-4.1.1-GCC-11.2.0.eb
   - FFTW-3.3.10-gompi-2021b.eb
   - BLIS-0.8.1-GCC-11.2.0.eb

--- a/eessi-2023.06-eb-4.7.2-2022a.yml
+++ b/eessi-2023.06-eb-4.7.2-2022a.yml
@@ -1,10 +1,10 @@
 easyconfigs:
   - GCC-11.3.0
   - git-2.36.0-GCCcore-11.3.0-nodocs.eb
-  - CMake-3.23.1-GCCcore-11.3.0.eb
-  # - CMake-3.23.1-GCCcore-11.3.0.eb:
-  #     options:
-  #       include-easyblocks-from-pr: 2248
+  # - CMake-3.23.1-GCCcore-11.3.0.eb
+  - CMake-3.23.1-GCCcore-11.3.0.eb:
+      options:
+        include-easyblocks-from-pr: 2248
   - BLIS-0.9.0-GCC-11.3.0.eb
   - OpenMPI-4.1.4-GCC-11.3.0.eb
   - FFTW.MPI-3.3.10-gompi-2022a.eb

--- a/eessi-2023.06-eb-4.7.2-2022b.yml
+++ b/eessi-2023.06-eb-4.7.2-2022b.yml
@@ -1,10 +1,10 @@
 easyconfigs:
   - GCC-12.2.0
   - git-2.38.1-GCCcore-12.2.0-nodocs.eb
-  - CMake-3.24.3-GCCcore-12.2.0.eb
-  # - CMake-3.24.3-GCCcore-12.2.0.eb:
-  #     options:
-  #       include-easyblocks-from-pr: 2248
+  # - CMake-3.24.3-GCCcore-12.2.0.eb
+  - CMake-3.24.3-GCCcore-12.2.0.eb:
+      options:
+        include-easyblocks-from-pr: 2248
   - BLIS-0.9.0-GCC-12.2.0.eb
   - OpenMPI-4.1.4-GCC-12.2.0.eb
   - FFTW.MPI-3.3.10-gompi-2022b.eb


### PR DESCRIPTION
Rebuilds CMake for `foss/2021a`, `foss/2021b`, `foss/2022a` and `foss/2022b`:

- `CMake-3.20.1-GCCcore-10.3.0.eb`
- `CMake-3.21.1-GCCcore-11.2.0.eb`
- `CMake-3.23.1-GCCcore-11.3.0.eb`
- `CMake-3.24.3-GCCcore-12.2.0.eb`

Requires removal of module files and software directories on Stratum-0 before starting the building.