### PR TITLE
{2023.06}[foss/2021b] R V4.2.0

### DIFF
--- a/eessi-2023.06-eb-4.7.2-2021b.yml
+++ b/eessi-2023.06-eb-4.7.2-2021b.yml
@@ -13,3 +13,4 @@ easyconfigs:
   #       include-easyblocks-from-pr: 2248
   # - zlib-1.2.11-GCCcore-11.2.0
   - QuantumESPRESSO-6.8-foss-2021b.eb
+  - R-4.2.0-foss-2021b.eb


### PR DESCRIPTION
Trying to build R V4.2.0 instead of V4.1.0 as the latter requires modifications in the eb_hook file.