### PR TITLE
{2023.06}[foss/2021a] Yambo V5.1.1

### DIFF
--- a/eessi-2023.06-eb-4.7.2-2021a.yml
+++ b/eessi-2023.06-eb-4.7.2-2021a.yml
@@ -20,3 +20,7 @@ easyconfigs:
         options:
           from-pr: 18446
   - WRF-4.3-foss-2021a-dmpar.eb
+  - Yambo-5.1.1-foss-2021a.eb:
+        options:
+          from-pr: 18905
+      


### PR DESCRIPTION
Trying to build Yambo which was initially built on intel-toolchain on foss/2021a.
Yambo is not yet supported on the ARM architecture.