### PR TITLE
{2023.06}[foss/2022a] GROMACS V2023.1

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - GROMACS-2023.1-foss-2022a.eb


### PR DESCRIPTION
Trying to add GROMACS/2023.1-foss/2022a to NESSI stack.

All modules that will be installed:
```
* scikit-build/0.15.0-GCCcore-11.3.0 (scikit-build-0.15.0-GCCcore-11.3.0.eb)
* networkx/2.8.4-foss-2022a (networkx-2.8.4-foss-2022a.eb)
* GROMACS/2023.1-foss-2022a (GROMACS-2023.1-foss-2022a.eb)
```