### PR TITLE
{2023.06}[foss/2022a,system] add common dependencies - set 1

### DIFF
--- a/.github/workflows/test_eessi.yml
+++ b/.github/workflows/test_eessi.yml
@@ -26,6 +26,7 @@ jobs:
         - eessi-2023.06-eb-4.7.2-system.yml
         - eessi-2023.06-eb-4.8.0-system.yml
         - eessi-2023.06-eb-4.8.1-2022a.yml
+        - eessi-2023.06-eb-4.8.1-system.yml
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -52,7 +52,7 @@ if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules ]; then
     find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules -type l | grep -v '/\.wh\.' >> ${files_list}
     # module files and symlinks
     find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules/all -type f -o -type l \
-        | grep -v '/\.wh\.' | sed -e 's/.lua$//' | sed -e 's@.*/modules/all/@@g' | sort -u \
+        | grep -v '/\.wh\.' | grep -v '/\.modulerc\.lua' | sed -e 's/.lua$//' | sed -e 's@.*/modules/all/@@g' | sort -u \
         >> ${module_files_list}
 fi
 if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software -a -r ${module_files_list} ]; then

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -5,8 +5,6 @@ easyconfigs:
   - Bowtie2-2.4.5-GCC-11.3.0.eb
   - FastTree-2.1.11-GCCcore-11.3.0.eb
   - SAMtools-1.16.1-GCC-11.3.0.eb
-  # wraps around Java/11.0.20
-  - Java-11.eb
   - gzip-1.12-GCCcore-11.3.0.eb
   - lz4-1.9.3-GCCcore-11.3.0.eb
   - zstd-1.5.2-GCCcore-11.3.0.eb

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -5,6 +5,8 @@ easyconfigs:
   - Bowtie2-2.4.5-GCC-11.3.0.eb
   - FastTree-2.1.11-GCCcore-11.3.0.eb
   - SAMtools-1.16.1-GCC-11.3.0.eb
+  # wraps around Java/11.0.20
+  - Java-11.eb
   - gzip-1.12-GCCcore-11.3.0.eb
   - lz4-1.9.3-GCCcore-11.3.0.eb
   - zstd-1.5.2-GCCcore-11.3.0.eb

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -5,3 +5,6 @@ easyconfigs:
   - Bowtie2-2.4.5-GCC-11.3.0.eb
   - FastTree-2.1.11-GCCcore-11.3.0.eb
   - SAMtools-1.16.1-GCC-11.3.0.eb
+  - gzip-1.12-GCCcore-11.3.0.eb
+  - lz4-1.9.3-GCCcore-11.3.0.eb
+  - zstd-1.5.2-GCCcore-11.3.0.eb

--- a/eessi-2023.06-eb-4.8.1-system.yml
+++ b/eessi-2023.06-eb-4.8.1-system.yml
@@ -1,0 +1,3 @@
+easyconfigs:
+  # wraps around Java/11.0.20
+  - Java-11.eb


### PR DESCRIPTION
Adds the following common dependencies

# foss/2022a
* gzip/1.12-GCCcore-11.3.0 (gzip-1.12-GCCcore-11.3.0.eb)
* lz4/1.9.3-GCCcore-11.3.0 (lz4-1.9.3-GCCcore-11.3.0.eb)
* zstd/1.5.2-GCCcore-11.3.0 (zstd-1.5.2-GCCcore-11.3.0.eb)

# system
* Java/11 (Java-11.eb)
