### PR TITLE
{2023.06}[foss/2022a] add Boost.Python/1.79.0

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -8,3 +8,4 @@ easyconfigs:
   - gzip-1.12-GCCcore-11.3.0.eb
   - lz4-1.9.3-GCCcore-11.3.0.eb
   - zstd-1.5.2-GCCcore-11.3.0.eb
+  - Boost.Python-1.79.0-GCC-11.3.0.eb


### PR DESCRIPTION
Will install the following packages (including dependencies):

* ICU/71.1-GCCcore-11.3.0 (ICU-71.1-GCCcore-11.3.0.eb)
* Boost/1.79.0-GCC-11.3.0 (Boost-1.79.0-GCC-11.3.0.eb)
* Boost.Python/1.79.0-GCC-11.3.0 (Boost.Python-1.79.0-GCC-11.3.0.eb)