### PR TITLE
{2023.06}[foss/2022a] add bio packages - set 2

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -9,7 +9,6 @@ easyconfigs:
   - lz4-1.9.3-GCCcore-11.3.0.eb
   - zstd-1.5.2-GCCcore-11.3.0.eb
   - AdapterRemoval-2.3.3-GCC-11.3.0.eb
-  - BBMap-39.01-GCC-11.3.0.eb
   - Beast-2.7.3-GCC-11.3.0.eb
   - BEDTools-2.30.0-GCC-11.3.0.eb
   - Bio-DB-HTS-3.01-GCC-11.3.0.eb

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -17,4 +17,3 @@ easyconfigs:
   - NCO-5.1.0-foss-2022a.eb
   - AdapterRemoval-2.3.3-GCC-11.3.0.eb
   - BEDTools-2.30.0-GCC-11.3.0.eb
-  - BWA-0.7.17-GCCcore-11.3.0.eb

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -9,7 +9,6 @@ easyconfigs:
   - lz4-1.9.3-GCCcore-11.3.0.eb
   - zstd-1.5.2-GCCcore-11.3.0.eb
   - AdapterRemoval-2.3.3-GCC-11.3.0.eb
-  - Beast-2.7.3-GCC-11.3.0.eb
   - BEDTools-2.30.0-GCC-11.3.0.eb
   - Bio-DB-HTS-3.01-GCC-11.3.0.eb
   - Bio-SearchIO-hmmer-1.7.3-GCC-11.3.0.eb

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -8,3 +8,10 @@ easyconfigs:
   - gzip-1.12-GCCcore-11.3.0.eb
   - lz4-1.9.3-GCCcore-11.3.0.eb
   - zstd-1.5.2-GCCcore-11.3.0.eb
+  - AdapterRemoval-2.3.3-GCC-11.3.0.eb
+  - BBMap-39.01-GCC-11.3.0.eb
+  - Beast-2.7.3-GCC-11.3.0.eb
+  - BEDTools-2.30.0-GCC-11.3.0.eb
+  - Bio-DB-HTS-3.01-GCC-11.3.0.eb
+  - Bio-SearchIO-hmmer-1.7.3-GCC-11.3.0.eb
+  - BWA-0.7.17-GCCcore-11.3.0.eb


### PR DESCRIPTION
Will install the following packages (including dependencies):

* AdapterRemoval/2.3.3-GCC-11.3.0 (AdapterRemoval-2.3.3-GCC-11.3.0.eb)
* BEDTools/2.30.0-GCC-11.3.0 (BEDTools-2.30.0-GCC-11.3.0.eb)
* ~BWA/0.7.17-GCCcore-11.3.0 (BWA-0.7.17-GCCcore-11.3.0.eb)~ removed because it failed to build for `aarch64/generic` $\longrightarrow$ open a separate PR for it
* ~BBMap/39.01-GCC-11.3.0 (BBMap-39.01-GCC-11.3.0.eb)~ removed because it failed repeatedly for `aarch64/generic` $\longrightarrow$ open a separate PR for it
* ~Beast/2.7.3-GCC-11.3.0 (Beast-2.7.3-GCC-11.3.0.eb)~ removed because dependency `Clang` failed to build for `aarch64/generic` $\longrightarrow$ open a separate PR for it
* ~Bio-DB-HTS/3.01-GCC-11.3.0 (Bio-DB-HTS-3.01-GCC-11.3.0.eb)~ removed because dependency `DB_File` failed to build for `aarch64/generic` $\longrightarrow$ open a separate PR for it
* ~Bio-SearchIO-hmmer/1.7.3-GCC-11.3.0 (Bio-SearchIO-hmmer-1.7.3-GCC-11.3.0.eb)~ removed because dependency `DB_File` failed to build for `aarch64/generic` $\longrightarrow$ open a separate PR for it