### PR TITLE
{2023.06}[foss/2022a] add NCO/5.1.0

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -8,7 +8,7 @@ easyconfigs:
   - gzip-1.12-GCCcore-11.3.0.eb
   - lz4-1.9.3-GCCcore-11.3.0.eb
   - zstd-1.5.2-GCCcore-11.3.0.eb
-  - netCDF-4.9.0-gompi-2022b.eb:
+  - netCDF-4.9.0-gompi-2022a.eb:
       # use updated CMakeMake easyblock to avoid that -DCMAKE_SKIP_RPATH=ON is used, which breaks the netCDF test step
       # see https://github.com/easybuilders/easybuild-easyblocks/pull/3012
       options:

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -8,3 +8,4 @@ easyconfigs:
   - gzip-1.12-GCCcore-11.3.0.eb
   - lz4-1.9.3-GCCcore-11.3.0.eb
   - zstd-1.5.2-GCCcore-11.3.0.eb
+  - NCO-5.1.0-foss-2022a.eb

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -8,4 +8,9 @@ easyconfigs:
   - gzip-1.12-GCCcore-11.3.0.eb
   - lz4-1.9.3-GCCcore-11.3.0.eb
   - zstd-1.5.2-GCCcore-11.3.0.eb
+  - netCDF-4.9.0-gompi-2022b.eb:
+      # use updated CMakeMake easyblock to avoid that -DCMAKE_SKIP_RPATH=ON is used, which breaks the netCDF test step
+      # see https://github.com/easybuilders/easybuild-easyblocks/pull/3012
+      options:
+        include-easyblocks-from-pr: 3012
   - NCO-5.1.0-foss-2022a.eb


### PR DESCRIPTION
Will install the following packages (including dependencies):

* ANTLR/2.7.7-GCCcore-11.3.0-Java-11 (ANTLR-2.7.7-GCCcore-11.3.0-Java-11.eb)
* Bison/3.8.2-GCCcore-11.3.0 (Bison-3.8.2-GCCcore-11.3.0.eb)
* Doxygen/1.9.4-GCCcore-11.3.0 (Doxygen-1.9.4-GCCcore-11.3.0.eb)
* ESMF/8.3.0-foss-2022a (ESMF-8.3.0-foss-2022a.eb)
* HDF5/1.12.2-gompi-2022a (HDF5-1.12.2-gompi-2022a.eb)
* libdap/3.20.11-GCCcore-11.3.0 (libdap-3.20.11-GCCcore-11.3.0.eb)
* libiconv/1.17-GCCcore-11.3.0 (libiconv-1.17-GCCcore-11.3.0.eb)
* libtirpc/1.3.2-GCCcore-11.3.0 (libtirpc-1.3.2-GCCcore-11.3.0.eb)
* NCO/5.1.0-foss-2022a (NCO-5.1.0-foss-2022a.eb)
* netCDF/4.9.0-gompi-2022a (netCDF-4.9.0-gompi-2022a.eb)
* netCDF-C++4/4.3.1-gompi-2022a (netCDF-C++4-4.3.1-gompi-2022a.eb)
* netCDF-Fortran/4.6.0-gompi-2022a (netCDF-Fortran-4.6.0-gompi-2022a.eb)
* PCRE/8.45-GCCcore-11.3.0 (PCRE-8.45-GCCcore-11.3.0.eb)
* Szip/2.1.1-GCCcore-11.3.0 (Szip-2.1.1-GCCcore-11.3.0.eb)
* UDUNITS/2.2.28-GCCcore-11.3.0 (UDUNITS-2.2.28-GCCcore-11.3.0.eb)