### PR TITLE
{2023.06}[foss/2022a] add bio packages - set 3

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -15,3 +15,12 @@ easyconfigs:
       options:
         include-easyblocks-from-pr: 3012
   - NCO-5.1.0-foss-2022a.eb
+  - Pysam-0.20.0-GCC-11.3.0.eb
+  - TransDecoder-5.5.0-GCC-11.3.0.eb
+  - VCFtools-0.1.16-GCC-11.3.0.eb
+  - VSEARCH-2.22.1-GCC-11.3.0.eb
+  - XML-LibXML-2.0207-GCCcore-11.3.0.eb
+  - CMake-3.24.3-GCCcore-11.3.0.eb
+  - elfutils-0.187-GCCcore-11.3.0.eb
+  - Ninja-1.10.2-GCCcore-11.3.0.eb
+  - Z3-4.10.2-GCCcore-11.3.0.eb

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -18,7 +18,6 @@ easyconfigs:
   - Pysam-0.20.0-GCC-11.3.0.eb
   - TransDecoder-5.5.0-GCC-11.3.0.eb
   - VCFtools-0.1.16-GCC-11.3.0.eb
-  - VSEARCH-2.22.1-GCC-11.3.0.eb
   - XML-LibXML-2.0207-GCCcore-11.3.0.eb
   - CMake-3.24.3-GCCcore-11.3.0.eb
   - elfutils-0.187-GCCcore-11.3.0.eb


### PR DESCRIPTION
Will install the following packages (incl dependencies) + some dependencies from original #183 (those built on all architectures ... we include them here so they will be available.

Packages + dependencies:
* Pysam/0.20.0-GCC-11.3.0 (Pysam-0.20.0-GCC-11.3.0.eb)
* TransDecoder/5.5.0-GCC-11.3.0 (TransDecoder-5.5.0-GCC-11.3.0.eb)
  * CD-HIT/4.8.1-GCC-11.3.0 (CD-HIT-4.8.1-GCC-11.3.0.eb)
* VCFtools/0.1.16-GCC-11.3.0 (VCFtools-0.1.16-GCC-11.3.0.eb)
* ~VSEARCH/2.22.1-GCC-11.3.0 (VSEARCH-2.22.1-GCC-11.3.0.eb)~ removed because it failed to build on all architectures $\longrightarrow$ build in separate PR

Dependencies from #183:
* CMake/3.24.3-GCCcore-11.3.0 (CMake-3.24.3-GCCcore-11.3.0.eb)
* elfutils/0.187-GCCcore-11.3.0 (elfutils-0.187-GCCcore-11.3.0.eb)
* Ninja/1.10.2-GCCcore-11.3.0 (Ninja-1.10.2-GCCcore-11.3.0.eb)
* XML-LibXML/2.0207-GCCcore-11.3.0 (XML-LibXML-2.0207-GCCcore-11.3.0.eb)
* Z3/4.10.2-GCCcore-11.3.0 (Z3-4.10.2-GCCcore-11.3.0.eb)