### PR TITLE
{2023.06}[foss/2022a] add SciPy-bundle

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -18,6 +18,9 @@ except ImportError:
     from distutils.version import LooseVersion
 
 
+CPU_TARGET_NEOVERSE_V1 = 'aarch64/neoverse_v1'
+
+
 EESSI_RPATH_OVERRIDE_ATTR = 'orig_rpath_override_dirs'
 
 
@@ -248,6 +251,23 @@ def pre_configure_hook_wrf_aarch64(self, *args, **kwargs):
     else:
         raise EasyBuildError("WRF-specific hook triggered for non-WRF easyconfig?!")
 
+
+def pre_test_hook(self,*args, **kwargs):
+    """Main pre-test hook: trigger custom functions based on software name."""
+    if self.name in PRE_TEST_HOOKS:
+        PRE_TEST_HOOKS[self.name](self, *args, **kwargs)
+
+
+def pre_test_hook_ignore_failing_tests_SciPybundle(self, *args, **kwargs):
+    """
+    Pre-test hook for SciPy-bundle: skip failing tests for SciPy-bundle 2021.10 (currently the only version that is failing).
+    In previous versions we were not as strict yet on the numpy/SciPy tests
+    """
+    cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
+    if self.name == 'SciPy-bundle' and self.version == '2021.10' and cpu_target == CPU_TARGET_NEOVERSE_V1:
+        self.cfg['testopts'] = "|| echo ignoring failing tests" 
+
+
 PARSE_HOOKS = {
     'CGAL': parse_hook_cgal_toolchainopts_precise,
     'fontconfig': parse_hook_fontconfig_add_fonts,
@@ -264,4 +284,8 @@ PRE_CONFIGURE_HOOKS = {
     'MetaBAT': pre_configure_hook_metabat_filtered_zlib_dep,
     'OpenBLAS': pre_configure_hook_openblas_optarch_generic,
     'WRF': pre_configure_hook_wrf_aarch64,
+}
+
+PRE_TEST_HOOKS = {
+    'SciPy-bundle': pre_test_hook_ignore_failing_tests_SciPybundle,
 }

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -15,3 +15,4 @@ easyconfigs:
       options:
         include-easyblocks-from-pr: 3012
   - NCO-5.1.0-foss-2022a.eb
+  - SciPy-bundle-2022.05-foss-2022a.eb


### PR DESCRIPTION
Will install the following packages (incl dependencies):

* Eigen/3.4.0-GCCcore-11.3.0 (Eigen-3.4.0-GCCcore-11.3.0.eb)
* pybind11/2.9.2-GCCcore-11.3.0 (pybind11-2.9.2-GCCcore-11.3.0.eb)
* hypothesis/6.46.7-GCCcore-11.3.0 (hypothesis-6.46.7-GCCcore-11.3.0.eb)
* SciPy-bundle/2022.05-foss-2022a (SciPy-bundle-2022.05-foss-2022a.eb)

Also syncs `eb_hooks.py` with what is used by EESSI/2023.06 (although likely not necessary here due to other version and architecture).