### PR TITLE
{2023.06}[foss/2022a] add Xvfb

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -15,3 +15,8 @@ easyconfigs:
       options:
         include-easyblocks-from-pr: 3012
   - NCO-5.1.0-foss-2022a.eb
+  - Xvfb-21.1.3-GCCcore-11.3.0.eb:
+      # enable exec permissions for xvfb-run after copying;
+      # need to also enable user write permissions on xvfb-run to ensure that copying with preserved permissions works
+      options:
+        from-pr: 18834


### PR DESCRIPTION
Will install the following packages (incl dependencies):

* libxslt/1.1.34-GCCcore-11.3.0 (libxslt-1.1.34-GCCcore-11.3.0.eb)
* pixman/0.40.0-GCCcore-11.3.0 (pixman-0.40.0-GCCcore-11.3.0.eb)
* Meson/0.62.1-GCCcore-11.3.0 (Meson-0.62.1-GCCcore-11.3.0.eb)
* nettle/3.8-GCCcore-11.3.0 (nettle-3.8-GCCcore-11.3.0.eb)
* Mako/1.2.0-GCCcore-11.3.0 (Mako-1.2.0-GCCcore-11.3.0.eb)
* libpng/1.6.37-GCCcore-11.3.0 (libpng-1.6.37-GCCcore-11.3.0.eb)
* libunwind/1.6.2-GCCcore-11.3.0 (libunwind-1.6.2-GCCcore-11.3.0.eb)
* Brotli/1.0.9-GCCcore-11.3.0 (Brotli-1.0.9-GCCcore-11.3.0.eb)
* freetype/2.12.1-GCCcore-11.3.0 (freetype-2.12.1-GCCcore-11.3.0.eb)
* fontconfig/2.14.0-GCCcore-11.3.0 (fontconfig-2.14.0-GCCcore-11.3.0.eb)
* X11/20220504-GCCcore-11.3.0 (X11-20220504-GCCcore-11.3.0.eb)
* libdrm/2.4.110-GCCcore-11.3.0 (libdrm-2.4.110-GCCcore-11.3.0.eb)
* libglvnd/1.4.0-GCCcore-11.3.0 (libglvnd-1.4.0-GCCcore-11.3.0.eb)
* LLVM/14.0.3-GCCcore-11.3.0 (LLVM-14.0.3-GCCcore-11.3.0.eb)
* Mesa/22.0.3-GCCcore-11.3.0 (Mesa-22.0.3-GCCcore-11.3.0.eb)
* Xvfb/21.1.3-GCCcore-11.3.0 (Xvfb-21.1.3-GCCcore-11.3.0.eb)