### PR TITLE
{2023.06}[foss/2022a] R/4.2.1

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -268,6 +268,32 @@ def pre_test_hook_ignore_failing_tests_SciPybundle(self, *args, **kwargs):
         self.cfg['testopts'] = "|| echo ignoring failing tests" 
 
 
+def pre_single_extension_hook(ext, *args, **kwargs):
+    """Main pre-configure hook: trigger custom functions based on software name."""
+    if ext.name in PRE_SINGLE_EXTENSION_HOOKS:
+        PRE_SINGLE_EXTENSION_HOOKS[ext.name](ext, *args, **kwargs)
+
+
+def pre_single_extension_testthat(ext, *args, **kwargs):
+    """
+    Pre-extension hook for testthat R package, to fix build on top of recent glibc.
+    """
+    if ext.name == 'testthat' and LooseVersion(ext.version) < LooseVersion('3.1.0'):
+        # use constant value instead of SIGSTKSZ for stack size,
+        # cfr. https://github.com/r-lib/testthat/issues/1373 + https://github.com/r-lib/testthat/pull/1403
+        ext.cfg['preinstallopts'] = "sed -i 's/SIGSTKSZ/32768/g' inst/include/testthat/vendor/catch.h && "
+
+
+def pre_single_extension_isoband(ext, *args, **kwargs):
+    """
+    Pre-extension hook for isoband R package, to fix build on top of recent glibc.
+    """
+    if ext.name == 'isoband' and LooseVersion(ext.version) < LooseVersion('0.2.5'):
+        # use constant value instead of SIGSTKSZ for stack size in vendored testthat included in isoband sources,
+        # cfr. https://github.com/r-lib/isoband/commit/6984e6ce8d977f06e0b5ff73f5d88e5c9a44c027
+        ext.cfg['preinstallopts'] = "sed -i 's/SIGSTKSZ/32768/g' src/testthat/vendor/catch.h && "
+
+
 PARSE_HOOKS = {
     'CGAL': parse_hook_cgal_toolchainopts_precise,
     'fontconfig': parse_hook_fontconfig_add_fonts,
@@ -288,4 +314,9 @@ PRE_CONFIGURE_HOOKS = {
 
 PRE_TEST_HOOKS = {
     'SciPy-bundle': pre_test_hook_ignore_failing_tests_SciPybundle,
+}
+
+PRE_SINGLE_EXTENSION_HOOKS = {
+    'isoband': pre_single_extension_isoband,
+    'testthat': pre_single_extension_testthat,
 }

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -9,11 +9,12 @@ easyconfigs:
   - lz4-1.9.3-GCCcore-11.3.0.eb
   - zstd-1.5.2-GCCcore-11.3.0.eb
   - Boost.Python-1.79.0-GCC-11.3.0.eb
-  - netCDF-4.9.0-gompi-2022a.eb:
-      # use updated CMakeMake easyblock to avoid that -DCMAKE_SKIP_RPATH=ON is used, which breaks the netCDF test step
-      # see https://github.com/easybuilders/easybuild-easyblocks/pull/3012
-      options:
-        include-easyblocks-from-pr: 3012
+  - netCDF-4.9.0-gompi-2022a.eb
+  # - netCDF-4.9.0-gompi-2022a.eb:
+  #     # use updated CMakeMake easyblock to avoid that -DCMAKE_SKIP_RPATH=ON is used, which breaks the netCDF test step
+  #     # see https://github.com/easybuilders/easybuild-easyblocks/pull/3012
+  #     options:
+  #       include-easyblocks-from-pr: 3012
   - NCO-5.1.0-foss-2022a.eb
   - AdapterRemoval-2.3.3-GCC-11.3.0.eb
   - BEDTools-2.30.0-GCC-11.3.0.eb
@@ -26,9 +27,11 @@ easyconfigs:
   - Ninja-1.10.2-GCCcore-11.3.0.eb
   - Z3-4.10.2-GCCcore-11.3.0.eb
   - SciPy-bundle-2022.05-foss-2022a.eb
-  - Xvfb-21.1.3-GCCcore-11.3.0.eb:
-      # enable exec permissions for xvfb-run after copying;
-      # need to also enable user write permissions on xvfb-run to ensure that copying with preserved permissions works
-      options:
-        from-pr: 18834
+  - Xvfb-21.1.3-GCCcore-11.3.0.eb
+  # - Xvfb-21.1.3-GCCcore-11.3.0.eb:
+  #     # enable exec permissions for xvfb-run after copying;
+  #     # need to also enable user write permissions on xvfb-run to ensure that copying with preserved permissions works
+  #     options:
+  #       from-pr: 18834
   - tbb-2021.5.0-GCCcore-11.3.0.eb
+  - R-4.2.1-foss-2022a.eb

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -65,4 +65,3 @@ easyconfigs:
         options:
           download-timeout: 1000
   - ASE-3.22.1-foss-2022a.eb
-  - R-4.2.1-foss-2022a.eb

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -34,4 +34,9 @@ easyconfigs:
   #     options:
   #       from-pr: 18834
   - tbb-2021.5.0-GCCcore-11.3.0.eb
+  # seems downloading nodejs (dependency of R) ran into timeout across jobs,
+  # hence increasing the timeout for downloading it
+  - nodejs-16.15.1-GCCcore-11.3.0.eb:
+      options:
+        download-timeout: 1000
   - R-4.2.1-foss-2022a.eb

--- a/eessi-2023.06-eb-4.8.2-2022a.yml
+++ b/eessi-2023.06-eb-4.8.2-2022a.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - CDO-2.0.6-gompi-2022a.eb
+  - R-4.2.1-foss-2022a.eb


### PR DESCRIPTION
Will install the following packages (incl dependencies):

* ATK/2.38.0-GCCcore-11.3.0 (ATK-2.38.0-GCCcore-11.3.0.eb)
* GDAL/3.5.0-foss-2022a (GDAL-3.5.0-foss-2022a.eb)
* Gdk-Pixbuf/2.42.8-GCCcore-11.3.0 (Gdk-Pixbuf-2.42.8-GCCcore-11.3.0.eb)
* GEOS/3.10.3-GCC-11.3.0 (GEOS-3.10.3-GCC-11.3.0.eb)
* Ghostscript/9.56.1-GCCcore-11.3.0 (Ghostscript-9.56.1-GCCcore-11.3.0.eb)
* googletest/1.11.0-GCCcore-11.3.0 (googletest-1.11.0-GCCcore-11.3.0.eb)
* GTK2/2.24.33-GCCcore-11.3.0 (GTK2-2.24.33-GCCcore-11.3.0.eb)
* HDF/4.2.15-GCCcore-11.3.0 (HDF-4.2.15-GCCcore-11.3.0.eb)
* ImageMagick/7.1.0-37-GCCcore-11.3.0 (ImageMagick-7.1.0-37-GCCcore-11.3.0.eb)
* libgeotiff/1.7.1-GCCcore-11.3.0 (libgeotiff-1.7.1-GCCcore-11.3.0.eb)
* LittleCMS/2.13.1-GCCcore-11.3.0 (LittleCMS-2.13.1-GCCcore-11.3.0.eb)
* nlohmann_json/3.10.5-GCCcore-11.3.0 (nlohmann_json-3.10.5-GCCcore-11.3.0.eb)
* OpenJPEG/2.5.0-GCCcore-11.3.0 (OpenJPEG-2.5.0-GCCcore-11.3.0.eb)
* PROJ/9.0.0-GCCcore-11.3.0 (PROJ-9.0.0-GCCcore-11.3.0.eb)
* R/4.2.1-foss-2022a (R-4.2.1-foss-2022a.eb)

The `eb_hooks.py` has been synchronised with EESSI/2023.06 concerning issues relevant for R.