### PR TITLE
{2023.06}[foss/2022a] CMSeq V1.0.4

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -32,3 +32,4 @@ easyconfigs:
       options:
         from-pr: 18834
   - tbb-2021.5.0-GCCcore-11.3.0.eb
+  - CMSeq-1.0.4-foss-2022a.eb


### PR DESCRIPTION
Trying to build CMSeq/1.0.4-foss-2022a as a step forward for getting closer to the current available HPC software stack.

Will install the following packages:

* Pysam/0.19.1-GCC-11.3.0 (Pysam-0.19.1-GCC-11.3.0.eb)
* pkgconfig/1.5.5-GCCcore-11.3.0-python (pkgconfig-1.5.5-GCCcore-11.3.0-python.eb)
* Biopython/1.79-foss-2022a (Biopython-1.79-foss-2022a.eb)
* bcbio-gff/0.7.0-foss-2022a (bcbio-gff-0.7.0-foss-2022a.eb)
* h5py/3.7.0-foss-2022a (h5py-3.7.0-foss-2022a.eb)
* biom-format/2.1.14-foss-2022a (biom-format-2.1.14-foss-2022a.eb)
* CMSeq/1.0.4-foss-2022a (CMSeq-1.0.4-foss-2022a.eb)