### PR TITLE
{2023.06}[foss/2022a] CP2K V9.1

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -32,3 +32,4 @@ easyconfigs:
       options:
         from-pr: 18834
   - tbb-2021.5.0-GCCcore-11.3.0.eb
+  - CP2K-9.1-foss-2022a.eb


### PR DESCRIPTION
Trying to build CP2K/9.1-foss/2022a as a step forward for getting closer to the current available HPC software stack.

Will install the following packages:

* libxsmm/1.17-GCC-11.3.0 (libxsmm-1.17-GCC-11.3.0.eb)
* libvori/220621-GCCcore-11.3.0 (libvori-220621-GCCcore-11.3.0.eb)
* xxd/8.2.4220-GCCcore-11.3.0 (xxd-8.2.4220-GCCcore-11.3.0.eb)
* libxc/5.2.3-GCC-11.3.0 (libxc-5.2.3-GCC-11.3.0.eb)
* Libint/2.7.2-GCC-11.3.0-lmax-6-cp2k (Libint-2.7.2-GCC-11.3.0-lmax-6-cp2k.eb)
* PLUMED/2.8.1-foss-2022a (PLUMED-2.8.1-foss-2022a.eb)
* CP2K/9.1-foss-2022a (CP2K-9.1-foss-2022a.eb)