### PR TITLE
{2023.06}[foss/2022a] Pango/1.50.7

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -32,3 +32,4 @@ easyconfigs:
       options:
         from-pr: 18834
   - tbb-2021.5.0-GCCcore-11.3.0.eb
+  - Pango-1.50.7-GCCcore-11.3.0.eb


### PR DESCRIPTION
Done separately to prepare for R.

Will install the following packages:

* FriBidi/1.0.12-GCCcore-11.3.0 (FriBidi-1.0.12-GCCcore-11.3.0.eb)
* GLib/2.72.1-GCCcore-11.3.0 (GLib-2.72.1-GCCcore-11.3.0.eb)
* cairo/1.17.4-GCCcore-11.3.0 (cairo-1.17.4-GCCcore-11.3.0.eb)
* GObject-Introspection/1.72.0-GCCcore-11.3.0 (GObject-Introspection-1.72.0-GCCcore-11.3.0.eb)
* HarfBuzz/4.2.1-GCCcore-11.3.0 (HarfBuzz-4.2.1-GCCcore-11.3.0.eb)
* Pango/1.50.7-GCCcore-11.3.0 (Pango-1.50.7-GCCcore-11.3.0.eb)