### PR TITLE
{2023.06}[foss/2022a] dependencies for R/4.2.1

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -32,3 +32,12 @@ easyconfigs:
       options:
         from-pr: 18834
   - tbb-2021.5.0-GCCcore-11.3.0.eb
+  - GLPK-5.0-GCCcore-11.3.0.eb
+  - libgit2-1.4.3-GCCcore-11.3.0.eb
+  - libGLU-9.0.2-GCCcore-11.3.0.eb
+  - libsndfile-1.1.0-GCCcore-11.3.0.eb
+  - LibTIFF-4.3.0-GCCcore-11.3.0.eb
+  - MPFR-4.1.0-GCCcore-11.3.0.eb
+  - NLopt-2.7.1-GCCcore-11.3.0.eb
+  - PCRE2-10.40-GCCcore-11.3.0.eb
+  - Tk-8.6.12-GCCcore-11.3.0.eb


### PR DESCRIPTION
Reduce number of outstanding dependencies for R.

Will install the following packages (incl dependencies):

* FLAC/1.3.4-GCCcore-11.3.0 (FLAC-1.3.4-GCCcore-11.3.0.eb)
* GLPK/5.0-GCCcore-11.3.0 (GLPK-5.0-GCCcore-11.3.0.eb)
* jbigkit/2.1-GCCcore-11.3.0 (jbigkit-2.1-GCCcore-11.3.0.eb)
* LAME/3.100-GCCcore-11.3.0 (LAME-3.100-GCCcore-11.3.0.eb)
* libdeflate/1.10-GCCcore-11.3.0 (libdeflate-1.10-GCCcore-11.3.0.eb)
* libgit2/1.4.3-GCCcore-11.3.0 (libgit2-1.4.3-GCCcore-11.3.0.eb)
* libGLU/9.0.2-GCCcore-11.3.0 (libGLU-9.0.2-GCCcore-11.3.0.eb)
* ~libjpeg-turbo/2.1.3-GCCcore-11.3.0 (libjpeg-turbo-2.1.3-GCCcore-11.3.0.eb)~ done in #195
* libogg/1.3.5-GCCcore-11.3.0 (libogg-1.3.5-GCCcore-11.3.0.eb)
* libopus/1.3.1-GCCcore-11.3.0 (libopus-1.3.1-GCCcore-11.3.0.eb)
* libsndfile/1.1.0-GCCcore-11.3.0 (libsndfile-1.1.0-GCCcore-11.3.0.eb)
* LibTIFF/4.3.0-GCCcore-11.3.0 (LibTIFF-4.3.0-GCCcore-11.3.0.eb)
* libvorbis/1.3.7-GCCcore-11.3.0 (libvorbis-1.3.7-GCCcore-11.3.0.eb)
* MPFR/4.1.0-GCCcore-11.3.0 (MPFR-4.1.0-GCCcore-11.3.0.eb)
* ~NASM/2.15.05-GCCcore-11.3.0 (NASM-2.15.05-GCCcore-11.3.0.eb)~ done in #195
* NLopt/2.7.1-GCCcore-11.3.0 (NLopt-2.7.1-GCCcore-11.3.0.eb)
* PCRE2/10.40-GCCcore-11.3.0 (PCRE2-10.40-GCCcore-11.3.0.eb)
* Tk/8.6.12-GCCcore-11.3.0 (Tk-8.6.12-GCCcore-11.3.0.eb)