### PR TITLE
{2023.06}[gompi/2022a] ecCodes V2.27.0

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -33,4 +33,6 @@ easyconfigs:
         from-pr: 18834
   - tbb-2021.5.0-GCCcore-11.3.0.eb
   - CMSeq-1.0.4-foss-2022a.eb
-  - ecCodes-2.27.0-gompi-2022a.eb
+  - ecCodes-2.27.0-gompi-2022a.eb:
+        options:
+          download-timeout: 1000

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -33,3 +33,4 @@ easyconfigs:
         from-pr: 18834
   - tbb-2021.5.0-GCCcore-11.3.0.eb
   - CMSeq-1.0.4-foss-2022a.eb
+  - ecCodes-2.27.0-gompi-2022a.eb


### PR DESCRIPTION
Trying to build ecCodes/2.27.0-gompi/20022a as a step forward for getting closer to the current available HPC software stack.
License: https://spdx.org/licenses/Apache-2.0.html
Will install the following packages:

```
* JasPer/2.0.33-GCCcore-11.3.0 (JasPer-2.0.33-GCCcore-11.3.0.eb)
* NASM/2.15.05-GCCcore-11.3.0 (NASM-2.15.05-GCCcore-11.3.0.eb)
* libjpeg-turbo/2.1.3-GCCcore-11.3.0 (libjpeg-turbo-2.1.3-GCCcore-11.3.0.eb)
* libaec/1.0.6-GCCcore-11.3.0 (libaec-1.0.6-GCCcore-11.3.0.eb)
* ecCodes/2.27.0-gompi-2022a (ecCodes-2.27.0-gompi-2022a.eb)
```