### PR TITLE
{2023.06}[foss/2022a] gmsh V4.11.1

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -33,3 +33,4 @@ easyconfigs:
         from-pr: 18834
   - tbb-2021.5.0-GCCcore-11.3.0.eb
   - CMSeq-1.0.4-foss-2022a.eb
+  - gmsh-4.11.1-foss-2022a.eb


### PR DESCRIPTION
Trying to build gmsh/4.11.1-foss/2022a as a step forward for getting closer to the current available HPC software stack.

Will install the following packages:

``` 
* SWIG/4.0.2-GCCcore-11.3.0 (SWIG-4.0.2-GCCcore-11.3.0.eb)
* METIS/5.1.0-GCCcore-11.3.0 (METIS-5.1.0-GCCcore-11.3.0.eb)
* FreeImage/3.18.0-GCCcore-11.3.0 (FreeImage-3.18.0-GCCcore-11.3.0.eb)
* MPFR/4.1.0-GCCcore-11.3.0 (MPFR-4.1.0-GCCcore-11.3.0.eb)
* NASM/2.15.05-GCCcore-11.3.0 (NASM-2.15.05-GCCcore-11.3.0.eb)
* libjpeg-turbo/2.1.3-GCCcore-11.3.0 (libjpeg-turbo-2.1.3-GCCcore-11.3.0.eb)
* xprop/1.2.5-GCCcore-11.3.0 (xprop-1.2.5-GCCcore-11.3.0.eb)
* Tk/8.6.12-GCCcore-11.3.0 (Tk-8.6.12-GCCcore-11.3.0.eb)
* ParMETIS/4.0.3-gompi-2022a (ParMETIS-4.0.3-gompi-2022a.eb)
* SCOTCH/7.0.1-gompi-2022a (SCOTCH-7.0.1-gompi-2022a.eb)
* MUMPS/5.5.1-foss-2022a-metis (MUMPS-5.5.1-foss-2022a-metis.eb)
* SuiteSparse/5.13.0-foss-2022a-METIS-5.1.0 (SuiteSparse-5.13.0-foss-2022a-METIS-5.1.0.eb)
* Hypre/2.25.0-foss-2022a (Hypre-2.25.0-foss-2022a.eb)
* SuperLU_DIST/8.1.0-foss-2022a (SuperLU_DIST-8.1.0-foss-2022a.eb)
* PETSc/3.17.4-foss-2022a (PETSc-3.17.4-foss-2022a.eb)
* SLEPc/3.17.2-foss-2022a (SLEPc-3.17.2-foss-2022a.eb)
* libGLU/9.0.2-GCCcore-11.3.0 (libGLU-9.0.2-GCCcore-11.3.0.eb)
* FLTK/1.3.8-GCCcore-11.3.0 (FLTK-1.3.8-GCCcore-11.3.0.eb)
* occt/7.5.0p1-foss-2022a (occt-7.5.0p1-foss-2022a.eb)
* gmsh/4.11.1-foss-2022a (gmsh-4.11.1-foss-2022a.eb)
``` 