### PR TITLE
{2023.06}[foss/2021b] ImageMagick/7.1.0-4

### DIFF
--- a/.github/workflows/test_eessi.yml
+++ b/.github/workflows/test_eessi.yml
@@ -25,6 +25,7 @@ jobs:
         - eessi-2023.06-eb-4.7.2-2022b.yml
         - eessi-2023.06-eb-4.7.2-system.yml
         - eessi-2023.06-eb-4.8.0-system.yml
+        - eessi-2023.06-eb-4.8.1-2021b.yml
         - eessi-2023.06-eb-4.8.1-2022a.yml
         - eessi-2023.06-eb-4.8.1-system.yml
     steps:

--- a/eessi-2023.06-eb-4.8.1-2021b.yml
+++ b/eessi-2023.06-eb-4.8.1-2021b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - ImageMagick-7.1.0-4-GCCcore-11.2.0.eb


### PR DESCRIPTION
`ImageMagick-7.1.0-37-GCCcore-11.3.0.eb` repeatedly fails to build with foss/2022a for all architectures in #189 but it was successfully build as part of https://github.com/EESSI/software-layer/pull/335 with foss/2021a. So we try to build that here to help debugging #189 

Packages (incl dependencies) to be installed:

* Bison/3.7.6-GCCcore-11.2.0 (Bison-3.7.6-GCCcore-11.2.0.eb)
* Brotli/1.0.9-GCCcore-11.2.0 (Brotli-1.0.9-GCCcore-11.2.0.eb)
* cairo/1.16.0-GCCcore-11.2.0 (cairo-1.16.0-GCCcore-11.2.0.eb)
* Doxygen/1.9.1-GCCcore-11.2.0 (Doxygen-1.9.1-GCCcore-11.2.0.eb)
* fontconfig/2.13.94-GCCcore-11.2.0 (fontconfig-2.13.94-GCCcore-11.2.0.eb)
* freetype/2.11.0-GCCcore-11.2.0 (freetype-2.11.0-GCCcore-11.2.0.eb)
* FriBidi/1.0.10-GCCcore-11.2.0 (FriBidi-1.0.10-GCCcore-11.2.0.eb)
* Ghostscript/9.54.0-GCCcore-11.2.0 (Ghostscript-9.54.0-GCCcore-11.2.0.eb)
* GLib/2.69.1-GCCcore-11.2.0 (GLib-2.69.1-GCCcore-11.2.0.eb)
* GObject-Introspection/1.68.0-GCCcore-11.2.0 (GObject-Introspection-1.68.0-GCCcore-11.2.0.eb)
* gzip/1.10-GCCcore-11.2.0 (gzip-1.10-GCCcore-11.2.0.eb)
* HarfBuzz/2.8.2-GCCcore-11.2.0 (HarfBuzz-2.8.2-GCCcore-11.2.0.eb)
* ICU/69.1-GCCcore-11.2.0 (ICU-69.1-GCCcore-11.2.0.eb)
* ImageMagick/7.1.0-4-GCCcore-11.2.0 (ImageMagick-7.1.0-4-GCCcore-11.2.0.eb)
* JasPer/2.0.33-GCCcore-11.2.0 (JasPer-2.0.33-GCCcore-11.2.0.eb)
* jbigkit/2.1-GCCcore-11.2.0 (jbigkit-2.1-GCCcore-11.2.0.eb)
* libiconv/1.16-GCCcore-11.2.0 (libiconv-1.16-GCCcore-11.2.0.eb)
* libjpeg-turbo/2.0.6-GCCcore-11.2.0 (libjpeg-turbo-2.0.6-GCCcore-11.2.0.eb)
* libpng/1.6.37-GCCcore-11.2.0 (libpng-1.6.37-GCCcore-11.2.0.eb)
* LibTIFF/4.3.0-GCCcore-11.2.0 (LibTIFF-4.3.0-GCCcore-11.2.0.eb)
* LittleCMS/2.12-GCCcore-11.2.0 (LittleCMS-2.12-GCCcore-11.2.0.eb)
* lz4/1.9.3-GCCcore-11.2.0 (lz4-1.9.3-GCCcore-11.2.0.eb)
* Meson/0.58.2-GCCcore-11.2.0 (Meson-0.58.2-GCCcore-11.2.0.eb)
* NASM/2.15.05-GCCcore-11.2.0 (NASM-2.15.05-GCCcore-11.2.0.eb)
* Ninja/1.10.2-GCCcore-11.2.0 (Ninja-1.10.2-GCCcore-11.2.0.eb)
* Pango/1.48.8-GCCcore-11.2.0 (Pango-1.48.8-GCCcore-11.2.0.eb)
* PCRE/8.45-GCCcore-11.2.0 (PCRE-8.45-GCCcore-11.2.0.eb)
* pixman/0.40.0-GCCcore-11.2.0 (pixman-0.40.0-GCCcore-11.2.0.eb)
* X11/20210802-GCCcore-11.2.0 (X11-20210802-GCCcore-11.2.0.eb)
* zstd/1.5.0-GCCcore-11.2.0 (zstd-1.5.0-GCCcore-11.2.0.eb)