### PR TITLE
{2023.06}[foss/2022a] MAKER V3.01.04

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -142,8 +142,8 @@ def parse_hook_blast_builddependencies(ec, eprefix):
     """Append cpio as a builddependency for BLAST."""
     if ec.name == 'BLAST+':
         ec['builddependencies'].append(('cpio','2.14'))
-        print_msg("NOTE: Blast+ requires cpio during the build process, The original builddependency list has been appended with (cpio,2.14))"
-        ec.log.info("NOTE:  Blast+ requires cpio during the build process, The original builddependency list has been appended with (cpio,2.14))"
+        print_msg("NOTE: Blast+ requires cpio during the build process, The original builddependency list has been appended with (cpio,2.14)")
+        ec.log.info("NOTE:  Blast+ requires cpio during the build process, The original builddependency list has been appended with (cpio,2.14)")
     else:
         raise EasyBuildError("blast-specific hook triggered for non-blast easyconfig?!")
      

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -50,3 +50,4 @@ easyconfigs:
   - PCRE2-10.40-GCCcore-11.3.0.eb
   - Tk-8.6.12-GCCcore-11.3.0.eb
   - GROMACS-2023.1-foss-2022a.eb
+  - MAKER-3.01.04-foss-2022a.eb

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -55,7 +55,7 @@ easyconfigs:
       # Uses a custom hook since has zlib as dependency which has hard coded header and library path within Pillow code.
       options:
         from-pr: 18881
-  - cpio-2.14-foss-2022a.eb:
+  - cpio-2.14-GCCcore-11.3.0.eb:
       options:
         from-pr: 19017
   - BLAST+-2.13.0-gompi-2022a.eb


### PR DESCRIPTION
Trying to build MAKER/3.01.04-foss/2022a as a step forward for getting closer to the current available HPC software stack.

Will install the following packages:

```
* SNAP-HMM/20221022-GCC-11.3.0 (SNAP-HMM-20221022-GCC-11.3.0.eb)
* DB_File/1.858-GCCcore-11.3.0 (DB_File-1.858-GCCcore-11.3.0.eb)
* BioPerl/1.7.8-GCCcore-11.3.0 (BioPerl-1.7.8-GCCcore-11.3.0.eb)
* TRF/4.09.1-GCCcore-11.3.0 (TRF-4.09.1-GCCcore-11.3.0.eb)
* GeneMark-ET/4.71-GCCcore-11.3.0 (GeneMark-ET-4.71-GCCcore-11.3.0.eb)
* LMDB/0.9.29-GCCcore-11.3.0 (LMDB-0.9.29-GCCcore-11.3.0.eb)
* Exonerate/2.4.0-GCC-11.3.0 (Exonerate-2.4.0-GCC-11.3.0.eb)
* lpsolve/5.5.2.11-GCC-11.3.0 (lpsolve-5.5.2.11-GCC-11.3.0.eb)
* METIS/5.1.0-GCCcore-11.3.0 (METIS-5.1.0-GCCcore-11.3.0.eb)
* Boost.MPI/1.79.0-gompi-2022a (Boost.MPI-1.79.0-gompi-2022a.eb)
* BLAST+/2.13.0-gompi-2022a (BLAST+-2.13.0-gompi-2022a.eb)
* HMMER/3.3.2-gompi-2022a (HMMER-3.3.2-gompi-2022a.eb)
* RMBlast/2.13.0-gompi-2022a (RMBlast-2.13.0-gompi-2022a.eb)
* SuiteSparse/5.13.0-foss-2022a-METIS-5.1.0 (SuiteSparse-5.13.0-foss-2022a-METIS-5.1.0.eb)
* AUGUSTUS/3.5.0-foss-2022a (AUGUSTUS-3.5.0-foss-2022a.eb)
* RepeatMasker/4.1.4-foss-2022a (RepeatMasker-4.1.4-foss-2022a.eb)
* MAKER/3.01.04-foss-2022a (MAKER-3.01.04-foss-2022a.eb)
```