### PR TITLE
{2023.06}[foss/2022a] MUMPS-metis V5.5.1

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -50,3 +50,4 @@ easyconfigs:
   - PCRE2-10.40-GCCcore-11.3.0.eb
   - Tk-8.6.12-GCCcore-11.3.0.eb
   - GROMACS-2023.1-foss-2022a.eb
+  - MUMPS-5.5.1-foss-2022a-metis.eb


### PR DESCRIPTION
Trying to build MUMPS-metis/5.5.1-foss/2022a as a step forward for getting closer to the current available HPC software stack.
License: https://spdx.org/licenses/BSD-3-Clause.html
Will install the following packages:
```
* METIS/5.1.0-GCCcore-11.3.0 (METIS-5.1.0-GCCcore-11.3.0.eb)
* SCOTCH/7.0.1-gompi-2022a (SCOTCH-7.0.1-gompi-2022a.eb)
* MUMPS/5.5.1-foss-2022a-metis (MUMPS-5.5.1-foss-2022a-metis.eb)
```