### PR TITLE
{2023.06}[foss/2022a] Pillow V9.1.1

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -178,7 +178,7 @@ def parse_hook_openblas_relax_lapack_tests_num_errors(ec, eprefix):
 
 
 def parse_hook_pillow_set_cpath_library_path(ec, eprefix):
-    """Get CPATH and LIBRARY_PATH environment variables from the environment"""
+    """Extend CPATH and LIBRARY_PATH environment variables using EESSI_EPREFIX."""
     if ec.name == 'Pillow':
         EESSI_CPATH = os.getenv('EESSI_EPREFIX') + '/usr/include'
         EESSI_LIB_PATH = os.getenv('EESSI_EPREFIX') + '/usr/lib64'

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -66,23 +66,6 @@ def parse_hook(ec, *args, **kwargs):
         PARSE_HOOKS[ec.name](ec, eprefix)
 
 
-def parse_hook_pillow_set_cpath_library_path(ec, eprefix):
-    """Get EESSI_CPATH environment variable from the environment"""
-    if ec.name == 'Pillow':
-        EESSI_CPATH = os.getenv('EESSI_EPREFIX') + '/usr/include'
-        EESSI_LIB_PATH = os.getenv('EESSI_EPREFIX') + '/usr/lib64'
-        print_msg("NOTE:Pillow has zlib as a dependancy,the original CPATH value: (%s) has been extended with (%s)",
-                  os.getenv('CPATH'),  EESSI_CPATH)
-        print_msg("NOTE:Pillow has zlib as a dependancy,the original LIBRARY_PATH value: (%s) has been extended with (%s)",
-                  os.getenv('LIBRARY_PATH'),  EESSI_LIB_PATH)
-        ec.log.info("NOTE:Pillow has zlib as a dependancy,the original CPATH value: (%s)  has been extended with (%s)",
-                    os.getenv('CPATH'), EESSI_CPATH)
-        ec.log.info("NOTE:Pillow has zlib as a dependancy,the original LIBRARY_VALUE value: (%s) has been extended with (%s)",
-                    os.getenv('LIBRARY_PATH'), EESSI_LIB_PATH)
-        os.environ['CPATH'] = os.pathsep.join(filter(None,[os.environ.get('CPATH',''), EESSI_CPATH]))
-        os.environ['LIBRARY_PATH'] = os.pathsep.join(filter(None,[os.environ.get('LIBRARY_PATH',''), EESSI_LIB_PATH]))
-
-
 def pre_prepare_hook(self, *args, **kwargs):
     """Main pre-prepare hook: trigger custom functions."""
 
@@ -194,6 +177,23 @@ def parse_hook_openblas_relax_lapack_tests_num_errors(ec, eprefix):
         raise EasyBuildError("OpenBLAS-specific hook triggered for non-OpenBLAS easyconfig?!")
 
 
+def parse_hook_pillow_set_cpath_library_path(ec, eprefix):
+    """Get CPATH and LIBRARY_PATH environment variables from the environment"""
+    if ec.name == 'Pillow':
+        EESSI_CPATH = os.getenv('EESSI_EPREFIX') + '/usr/include'
+        EESSI_LIB_PATH = os.getenv('EESSI_EPREFIX') + '/usr/lib64'
+        print_msg("NOTE: Pillow has zlib as a dependancy, The original CPATH value: (%s) has been extended with (%s)",
+                  os.getenv('CPATH'),  EESSI_CPATH)
+        print_msg("NOTE: Pillow has zlib as a dependancy, The original LIBRARY_PATH value: (%s) has been extended with (%s)",
+                  os.getenv('LIBRARY_PATH'),  EESSI_LIB_PATH)
+        ec.log.info("NOTE: Pillow has zlib as a dependancy, The original CPATH value: (%s)  has been extended with (%s)",
+                    os.getenv('CPATH'), EESSI_CPATH)
+        ec.log.info("NOTE: Pillow has zlib as a dependancy, The original LIBRARY_VALUE value: (%s) has been extended with (%s)",
+                    os.getenv('LIBRARY_PATH'), EESSI_LIB_PATH)
+        os.environ['CPATH'] = os.pathsep.join(filter(None,[os.environ.get('CPATH',''), EESSI_CPATH]))
+        os.environ['LIBRARY_PATH'] = os.pathsep.join(filter(None,[os.environ.get('LIBRARY_PATH',''), EESSI_LIB_PATH]))
+
+
 def parse_hook_ucx_eprefix(ec, eprefix):
     """Make UCX aware of compatibility layer via additional configuration options."""
     if ec.name == 'UCX':
@@ -289,8 +289,8 @@ PARSE_HOOKS = {
     'CGAL': parse_hook_cgal_toolchainopts_precise,
     'fontconfig': parse_hook_fontconfig_add_fonts,
     'OpenBLAS': parse_hook_openblas_relax_lapack_tests_num_errors,
-    'UCX': parse_hook_ucx_eprefix,
     'Pillow': parse_hook_pillow_set_cpath_library_path,
+    'UCX': parse_hook_ucx_eprefix,
 }
 
 POST_PREPARE_HOOKS = {

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -66,6 +66,23 @@ def parse_hook(ec, *args, **kwargs):
         PARSE_HOOKS[ec.name](ec, eprefix)
 
 
+def parse_hook_pillow_set_cpath_library_path(ec, eprefix):
+    """Get EESSI_CPATH environment variable from the environment"""
+    if ec.name == 'Pillow':
+        EESSI_CPATH = os.getenv('EESSI_EPREFIX') + '/usr/include'
+        EESSI_LIB_PATH = os.getenv('EESSI_EPREFIX') + '/usr/lib64'
+        print_msg("NOTE:Pillow has zlib as a dependancy,the original CPATH value: (%s) has been extended with (%s)",
+                  os.getenv('CPATH'),  EESSI_CPATH)
+        print_msg("NOTE:Pillow has zlib as a dependancy,the original LIBRARY_PATH value: (%s) has been extended with (%s)",
+                  os.getenv('LIBRARY_PATH'),  EESSI_LIB_PATH)
+        ec.log.info("NOTE:Pillow has zlib as a dependancy,the original CPATH value: (%s)  has been extended with (%s)",
+                    os.getenv('CPATH'), EESSI_CPATH)
+        ec.log.info("NOTE:Pillow has zlib as a dependancy,the original LIBRARY_VALUE value: (%s) has been extended with (%s)",
+                    os.getenv('LIBRARY_PATH'), EESSI_LIB_PATH)
+        os.environ['CPATH'] = os.pathsep.join(filter(None,[os.environ.get('CPATH',''), EESSI_CPATH]))
+        os.environ['LIBRARY_PATH'] = os.pathsep.join(filter(None,[os.environ.get('LIBRARY_PATH',''), EESSI_LIB_PATH]))
+
+
 def pre_prepare_hook(self, *args, **kwargs):
     """Main pre-prepare hook: trigger custom functions."""
 
@@ -273,6 +290,7 @@ PARSE_HOOKS = {
     'fontconfig': parse_hook_fontconfig_add_fonts,
     'OpenBLAS': parse_hook_openblas_relax_lapack_tests_num_errors,
     'UCX': parse_hook_ucx_eprefix,
+    'Pillow': parse_hook_pillow_set_cpath_library_path,
 }
 
 POST_PREPARE_HOOKS = {

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -51,3 +51,7 @@ easyconfigs:
   - Tk-8.6.12-GCCcore-11.3.0.eb
   - GROMACS-2023.1-foss-2022a.eb
   - MUMPS-5.5.1-foss-2022a-metis.eb
+  - Pillow-9.1.1-GCCcore-11.3.0.eb:
+      # Uses a custom hook since has zlib as dependency which has hard coded header and library path within Pillow code.
+      options:
+        from-pr: 18881


### PR DESCRIPTION
The actual build issue with Pillow is that it can't find zlib through the  hardcoded paths, the problem is solved by using --disable-platform-guessing (which was introduced in https://github.com/easybuilders/easybuild-easyconfigs/pull/18881), and adding the appropriate paths to $CPATH and $LIBRARY_PATH via a hook.
License: https://spdx.org/licenses/HPND.html
Will install the following package:
```
Pillow/9.1.1-GCCcore-11.3.0 (Pillow-9.1.1-GCCcore-11.3.0.eb)
```