### PR TITLE
{2023.06}[gompi/2022a] OpenBabel V3.1.1

### DIFF
--- a/.github/workflows/test_eessi.yml
+++ b/.github/workflows/test_eessi.yml
@@ -27,6 +27,7 @@ jobs:
         - eessi-2023.06-eb-4.8.0-system.yml
         - eessi-2023.06-eb-4.8.1-2022a.yml
         - eessi-2023.06-eb-4.8.1-system.yml
+        - eessi-2023.06-eb-4.8.2-2022a.yml
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -51,3 +51,4 @@ easyconfigs:
   - Tk-8.6.12-GCCcore-11.3.0.eb
   - GROMACS-2023.1-foss-2022a.eb
   - MUMPS-5.5.1-foss-2022a-metis.eb
+  - OpenBabel-3.1.1-gompi-2022a.eb


### PR DESCRIPTION
Trying to build OpenBabel/3.1.1-gompi/2022a as a step forward for getting closer to the current available HPC software stack.
License:https://spdx.org/licenses/GPL-2.0-only.html
Will install the following packages:
```
* SWIG/4.0.2-GCCcore-11.3.0 (SWIG-4.0.2-GCCcore-11.3.0.eb)
* RapidJSON/1.1.0-GCCcore-11.3.0 (RapidJSON-1.1.0-GCCcore-11.3.0.eb)
* maeparser/1.3.0-gompi-2022a (maeparser-1.3.0-gompi-2022a.eb)
* CoordgenLibs/3.0.1-gompi-2022a (CoordgenLibs-3.0.1-gompi-2022a.eb)
* OpenBabel/3.1.1-gompi-2022a (OpenBabel-3.1.1-gompi-2022a.eb)
```