### PR TITLE
{2023.06}[foss/2022a] jax V0.4.4/CUDA V11.7.0

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -55,3 +55,4 @@ easyconfigs:
       # Uses a custom hook since has zlib as dependency which has hard coded header and library path within Pillow code.
       options:
         from-pr: 18881
+  - jax-0.4.4-foss-2022a-CUDA-11.7.0.eb


### PR DESCRIPTION
Trying to build jax/0.4.4-CUDA/11.7.0 as a step forward for getting closer to the current available HPC software stack.

Will install the following packages:

```
* Zip/3.0-GCCcore-11.3.0 (Zip-3.0-GCCcore-11.3.0.eb)
* CUDA/11.7.0 (CUDA-11.7.0.eb)
* cuDNN/8.4.1.50-CUDA-11.7.0 (cuDNN-8.4.1.50-CUDA-11.7.0.eb)
* cppy/1.2.1-GCCcore-11.3.0 (cppy-1.2.1-GCCcore-11.3.0.eb)
* flatbuffers-python/2.0-GCCcore-11.3.0 (flatbuffers-python-2.0-GCCcore-11.3.0.eb)
* Bazel/5.1.1-GCCcore-11.3.0 (Bazel-5.1.1-GCCcore-11.3.0.eb)
* pytest-xdist/2.5.0-GCCcore-11.3.0 (pytest-xdist-2.5.0-GCCcore-11.3.0.eb)
* GDRCopy/2.3-GCCcore-11.3.0 (GDRCopy-2.3-GCCcore-11.3.0.eb)
* UCX-CUDA/1.12.1-GCCcore-11.3.0-CUDA-11.7.0 (UCX-CUDA-1.12.1-GCCcore-11.3.0-CUDA-11.7.0.eb)
* NCCL/2.12.12-GCCcore-11.3.0-CUDA-11.7.0 (NCCL-2.12.12-GCCcore-11.3.0-CUDA-11.7.0.eb)
* Qhull/2020.2-GCCcore-11.3.0 (Qhull-2020.2-GCCcore-11.3.0.eb)
* Tkinter/3.10.4-GCCcore-11.3.0 (Tkinter-3.10.4-GCCcore-11.3.0.eb)
* matplotlib/3.5.2-foss-2022a (matplotlib-3.5.2-foss-2022a.eb)
* jax/0.4.4-foss-2022a-CUDA-11.7.0 (jax-0.4.4-foss-2022a-CUDA-11.7.0.eb)
```