### PR TITLE
{2023.06}[foss/2022a] ParaView-mpi V5.10.1

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -56,3 +56,5 @@ easyconfigs:
       options:
         from-pr: 18881
   - ParaView-5.10.1-foss-2022a-mpi.eb
+        options:
+          download-timeout: 1000

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -55,3 +55,4 @@ easyconfigs:
       # Uses a custom hook since has zlib as dependency which has hard coded header and library path within Pillow code.
       options:
         from-pr: 18881
+  - ParaView-5.10.1-foss-2022a-mpi.eb

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -55,6 +55,6 @@ easyconfigs:
       # Uses a custom hook since has zlib as dependency which has hard coded header and library path within Pillow code.
       options:
         from-pr: 18881
-  - ParaView-5.10.1-foss-2022a-mpi.eb
+  - ParaView-5.10.1-foss-2022a-mpi.eb:
         options:
           download-timeout: 1000


### PR DESCRIPTION
Trying to build ParaView_mpi-foss/2022a as a step forward for getting closer to the current available HPC software stack.
license: https://spdx.org/licenses/BSD-3-Clause.html 
Will install the following packages:

```
* Python/2.7.18-GCCcore-11.3.0-bare (Python-2.7.18-GCCcore-11.3.0-bare.eb)
* ffnvcodec/11.1.5.2 (ffnvcodec-11.1.5.2.eb)
* re2c/2.2-GCCcore-11.3.0 (re2c-2.2-GCCcore-11.3.0.eb)
* double-conversion/3.2.0-GCCcore-11.3.0 (double-conversion-3.2.0-GCCcore-11.3.0.eb)
* x264/20220620-GCCcore-11.3.0 (x264-20220620-GCCcore-11.3.0.eb)
* Yasm/1.3.0-GCCcore-11.3.0 (Yasm-1.3.0-GCCcore-11.3.0.eb)
* x265/3.5-GCCcore-11.3.0 (x265-3.5-GCCcore-11.3.0.eb)
* FFmpeg/4.4.2-GCCcore-11.3.0 (FFmpeg-4.4.2-GCCcore-11.3.0.eb)
* graphite2/1.3.14-GCCcore-11.3.0 (graphite2-1.3.14-GCCcore-11.3.0.eb)
* snappy/1.1.9-GCCcore-11.3.0 (snappy-1.1.9-GCCcore-11.3.0.eb)
* NSPR/4.34-GCCcore-11.3.0 (NSPR-4.34-GCCcore-11.3.0.eb)
* NSS/3.79-GCCcore-11.3.0 (NSS-3.79-GCCcore-11.3.0.eb)
* Qt5/5.15.5-GCCcore-11.3.0 (Qt5-5.15.5-GCCcore-11.3.0.eb)
* ParaView/5.10.1-foss-2022a-mpi (ParaView-5.10.1-foss-2022a-mpi.eb)
```