### PR TITLE
{2023.06}[gompi/2022a] SRA-Toolkit V3.0.3

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -55,3 +55,4 @@ easyconfigs:
       # Uses a custom hook since has zlib as dependency which has hard coded header and library path within Pillow code.
       options:
         from-pr: 18881
+  - SRA-Toolkit-3.0.3-gompi-2022a.eb


### PR DESCRIPTION
Trying to build SRA-Toolkit/3.0.3-gompi/2022a as a step forward for getting closer to the current available HPC software stack.

Will install the following packages:

```
* Perl/5.34.1-GCCcore-11.3.0-minimal (Perl-5.34.1-GCCcore-11.3.0-minimal.eb)
* file/5.43-GCCcore-11.3.0 (file-5.43-GCCcore-11.3.0.eb)
* ncbi-vdb/3.0.2-gompi-2022a (ncbi-vdb-3.0.2-gompi-2022a.eb)
* SRA-Toolkit/3.0.3-gompi-2022a (SRA-Toolkit-3.0.3-gompi-2022a.eb)
```