### PR TITLE
{2023.06}[foss/2022a] RepeatMasker V4.1.4

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -55,3 +55,4 @@ easyconfigs:
       # Uses a custom hook since has zlib as dependency which has hard coded header and library path within Pillow code.
       options:
         from-pr: 18881
+  - RepeatMasker-4.1.4-foss-2022a.eb


### PR DESCRIPTION
Trying to build RepeatMasker/4.1.4-foss/2022a as a step forward for getting closer to the current available HPC software stack.

Will install the following packages:

```
* TRF/4.09.1-GCCcore-11.3.0 (TRF-4.09.1-GCCcore-11.3.0.eb)
* LMDB/0.9.29-GCCcore-11.3.0 (LMDB-0.9.29-GCCcore-11.3.0.eb)
* Boost.MPI/1.79.0-gompi-2022a (Boost.MPI-1.79.0-gompi-2022a.eb)
* HMMER/3.3.2-gompi-2022a (HMMER-3.3.2-gompi-2022a.eb)
* RMBlast/2.13.0-gompi-2022a (RMBlast-2.13.0-gompi-2022a.eb)
* RepeatMasker/4.1.4-foss-2022a (RepeatMasker-4.1.4-foss-2022a.eb)
```