### PR TITLE
{2023.06}[foss/2022a] Python-bare V2.7.18

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -194,6 +194,15 @@ def parse_hook_pillow_set_cpath_library_path(ec, eprefix):
         os.environ['LIBRARY_PATH'] = os.pathsep.join(filter(None,[os.environ.get('LIBRARY_PATH',''), EESSI_LIB_PATH]))
 
 
+
+def parse_hook_python_bare_set_LANG(ec, eprefix):
+    """Set the LANG variable to C.UTF-8 in case it was empty."""
+    if ec.name == 'Python' and ec.version =='2.7.18' and os.getenv('LANG') is None:
+        print_msg("NOTE: The environment variable: LANG will be set to C.UTF-8")
+        ec.log.info("NOTE: The environment variable: LANG will be set to C.UTF-8")
+        os.environ['LANG'] = 'C.UTF-8' 
+
+
 def parse_hook_ucx_eprefix(ec, eprefix):
     """Make UCX aware of compatibility layer via additional configuration options."""
     if ec.name == 'UCX':
@@ -290,6 +299,7 @@ PARSE_HOOKS = {
     'fontconfig': parse_hook_fontconfig_add_fonts,
     'OpenBLAS': parse_hook_openblas_relax_lapack_tests_num_errors,
     'Pillow': parse_hook_pillow_set_cpath_library_path,
+    'Python':  parse_hook_python_bare_set_LANG,
     'UCX': parse_hook_ucx_eprefix,
 }
 

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -198,9 +198,9 @@ def parse_hook_pillow_set_cpath_library_path(ec, eprefix):
 def parse_hook_python_bare_set_LANG(ec, eprefix):
     """Set the LANG variable to C.UTF-8 in case it was empty."""
     if ec.name == 'Python' and ec.version =='2.7.18' and os.getenv('LANG') is None:
-        print_msg("NOTE: The environment variable: LANG will be set to C.UTF-8")
-        ec.log.info("NOTE: The environment variable: LANG will be set to C.UTF-8")
-        os.environ['LANG'] = 'C.UTF-8' 
+        print_msg("NOTE: The environment variable: LANG will be set to C")
+        ec.log.info("NOTE: The environment variable: LANG will be set to C")
+        os.environ['LANG'] = 'C' 
 
 
 def parse_hook_ucx_eprefix(ec, eprefix):

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -196,11 +196,11 @@ def parse_hook_pillow_set_cpath_library_path(ec, eprefix):
 
 
 def parse_hook_python_bare_set_LANG(ec, eprefix):
-    """Set the LANG variable to C.UTF-8 in case it was empty."""
+    """Set the LANG variable to en_DK.UTF-8 in case it was empty."""
     if ec.name == 'Python' and ec.version =='2.7.18' and os.getenv('LANG') is None:
-        print_msg("NOTE: The environment variable: LANG will be set to C")
-        ec.log.info("NOTE: The environment variable: LANG will be set to C")
-        os.environ['LANG'] = 'C' 
+        print_msg("NOTE: The environment variable: LANG will be set to en_DK.UTF-8")
+        ec.log.info("NOTE: The environment variable: LANG will be set to en_DK.UTF-8")
+        os.environ['LANG'] = 'en_DK.UTF-8' 
 
 
 def parse_hook_ucx_eprefix(ec, eprefix):

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -201,6 +201,7 @@ def parse_hook_python_bare_set_LANG(ec, eprefix):
         print_msg("NOTE: The environment variable: LANG will be set to en_DK.UTF-8")
         ec.log.info("NOTE: The environment variable: LANG will be set to en_DK.UTF-8")
         os.environ['LANG'] = 'en_DK.UTF-8' 
+        print_msg("NOTE: The environment variable: LANG is set to %s", os.getenv('LANG'))
 
 
 def parse_hook_ucx_eprefix(ec, eprefix):

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -55,3 +55,4 @@ easyconfigs:
       # Uses a custom hook since has zlib as dependency which has hard coded header and library path within Pillow code.
       options:
         from-pr: 18881
+  - Python-2.7.18-GCCcore-11.3.0-bare.eb


### PR DESCRIPTION
Python-bare fails to build on Fram, suspecting a missing LANG variable.
Prepared a hook which sets LANG in case it was empty, just a test.