### PR TITLE
Drop-additional-github-tests

### DIFF
--- a/.github/workflows/test_eessi.yml
+++ b/.github/workflows/test_eessi.yml
@@ -12,12 +12,10 @@ jobs:
         EESSI_VERSION:
         - 2023.06
         EESSI_SOFTWARE_SUBDIR:
-        - aarch64/generic
         - x86_64/amd/zen2
         - x86_64/intel/broadwell
-#        - x86_64/intel/cascadelake
         - x86_64/intel/skylake_avx512
-#        - x86_64/generic
+        - x86_64/generic
         EASYSTACK_FILE:
         - eessi-2023.06-eb-4.7.2-2021a.yml
         - eessi-2023.06-eb-4.7.2-2021b.yml

--- a/.github/workflows/test_eessi.yml
+++ b/.github/workflows/test_eessi.yml
@@ -15,9 +15,9 @@ jobs:
         - aarch64/generic
         - x86_64/amd/zen2
         - x86_64/intel/broadwell
-        - x86_64/intel/cascadelake
+#        - x86_64/intel/cascadelake
         - x86_64/intel/skylake_avx512
-        - x86_64/generic
+#        - x86_64/generic
         EASYSTACK_FILE:
         - eessi-2023.06-eb-4.7.2-2021a.yml
         - eessi-2023.06-eb-4.7.2-2021b.yml


### PR DESCRIPTION
Removing the aarch64 and Cascadelake tests within github Workflows.