### PR TITLE
{2023.06}[system] EasyBuild V4.8.2

### DIFF
--- a/.github/workflows/test_eessi.yml
+++ b/.github/workflows/test_eessi.yml
@@ -27,7 +27,6 @@ jobs:
         - eessi-2023.06-eb-4.8.0-system.yml
         - eessi-2023.06-eb-4.8.1-2022a.yml
         - eessi-2023.06-eb-4.8.1-system.yml
-        - eessi-2023.06-eb-4.8.2-system.yml
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/.github/workflows/test_eessi.yml
+++ b/.github/workflows/test_eessi.yml
@@ -12,10 +12,10 @@ jobs:
         EESSI_VERSION:
         - 2023.06
         EESSI_SOFTWARE_SUBDIR:
-        - aarch64/generic
+#        - aarch64/generic
         - x86_64/amd/zen2
         - x86_64/intel/broadwell
-        - x86_64/intel/cascadelake
+#        - x86_64/intel/cascadelake
         - x86_64/intel/skylake_avx512
         - x86_64/generic
         EASYSTACK_FILE:
@@ -27,6 +27,7 @@ jobs:
         - eessi-2023.06-eb-4.8.0-system.yml
         - eessi-2023.06-eb-4.8.1-2022a.yml
         - eessi-2023.06-eb-4.8.1-system.yml
+        - eessi-2023.06-eb-4.8.2-system.yml
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/eessi-2023.06-eb-4.8.1-system.yml
+++ b/eessi-2023.06-eb-4.8.1-system.yml
@@ -1,3 +1,6 @@
 easyconfigs:
   # wraps around Java/11.0.20
   - Java-11.eb
+  - EasyBuild-4.8.2.eb:
+      options:
+        from-pr: 19105

--- a/eessi-2023.06-eb-4.8.2-system.yml
+++ b/eessi-2023.06-eb-4.8.2-system.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - EasyBuild-4.8.2.eb

--- a/eessi-2023.06-eb-4.8.2-system.yml
+++ b/eessi-2023.06-eb-4.8.2-system.yml
@@ -1,2 +1,4 @@
 easyconfigs:
-  - EasyBuild-4.8.2.eb
+  - EasyBuild-4.8.2.eb:
+      options:
+        from-pr: 19105

--- a/eessi-2023.06-eb-4.8.2-system.yml
+++ b/eessi-2023.06-eb-4.8.2-system.yml
@@ -1,4 +1,0 @@
-easyconfigs:
-  - EasyBuild-4.8.2.eb:
-      options:
-        from-pr: 19105


### PR DESCRIPTION
Adds EasyBuild 4.8.2 via a new easystack file for the system toolchain, also excludes CI tests for **aarch64** and **cascadelake**.

License: https://spdx.org/licenses/GPL-2.0-only.html

Will install the following packages:
```
EasyBuild-4.8.2.eb
```