### PR TITLE
{2023.06}[foss/2022b] Strace V6.6

### DIFF
--- a/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - strace-6.6-GCCcore-12.2.0.eb:
+        options:
+          from-pr: 19227


### PR DESCRIPTION
Trying to build Strace/6.6-foss/2022b as a step forward for adding a tool which helps in troubleshooting while building the HPC software stack.
License:https://spdx.org/licenses/GPL-2.0-or-later.html
Will install the following packages:

```strace-6.6-GCCcore-12.2.0.eb```
