### PR TITLE
do not include `cfg_files.sh` in scripts tarball

### DIFF
--- a/create_directory_tarballs.sh
+++ b/create_directory_tarballs.sh
@@ -42,7 +42,7 @@ echo_green "Done! Created tarball ${tarname}."
 tartmp=$(mktemp -t -d scripts.XXXXX)
 mkdir "${tartmp}/${version}"
 tarname="eessi-${version}-scripts-$(date +%s).tar.gz"
-curl -Ls ${SOFTWARE_LAYER_TARBALL_URL} | tar xzf - -C "${tartmp}/${version}" --strip-components=1 --no-wildcards-match-slash --wildcards '*/scripts/'
+curl -Ls ${SOFTWARE_LAYER_TARBALL_URL} | tar xzf - -C "${tartmp}/${version}" --strip-components=1 --no-wildcards-match-slash --wildcards '*/scripts/u*' '*/scripts/gpu_support/'
 tar czf "${tarname}" -C "${tartmp}" "${version}"
 rm -rf "${tartmp}"
 


### PR DESCRIPTION
The scripts tarball contains files under `<PREFIX>/versions/<VERSION>/scripts`