### PR TITLE
add broadwell support to archdetect

### DIFF
--- a/init/arch_specs/eessi_arch_x86.spec
+++ b/init/arch_specs/eessi_arch_x86.spec
@@ -1,6 +1,7 @@
 # x86_64 CPU architecture specifications
 # Software path in EESSI 	| Vendor ID 	| List of defining CPU features
-"x86_64/intel/haswell"		"GenuineIntel"	"avx2 fma" 		# Intel Haswell, Broadwell
+"x86_64/intel/haswell"		"GenuineIntel"	"avx2 fma"		# Intel Haswell
+"x86_64/intel/broadwell"	"GenuineIntel"	"avx2 fma rdseed adx"	# Intel Broadwell
 "x86_64/intel/skylake_avx512"	"GenuineIntel"	"avx2 fma avx512f avx512bw avx512cd avx512dq avx512vl"	# Intel Skylake, Cascade Lake
 "x86_64/amd/zen2"		"AuthenticAMD"	"avx2 fma"		# AMD Rome
 "x86_64/amd/zen3"		"AuthenticAMD"	"avx2 fma vaes"		# AMD Milan, Milan-X


### PR DESCRIPTION
Checked for different flags/features used by archspec. E.g., https://github.com/archspec/archspec-json/blob/d844bb36b21dfb9ff5d04727edfc08f592fc06af/cpu/microarchitectures.json