### PR TITLE
use archdetect

### DIFF
--- a/init/eessi_defaults
+++ b/init/eessi_defaults
@@ -11,6 +11,5 @@
 export EESSI_CVMFS_REPO="${EESSI_CVMFS_REPO_OVERRIDE:=/cvmfs/pilot.nessi.no}"
 export EESSI_VERSION="${EESSI_VERSION_OVERRIDE:=2023.06}"
 # use archdetect by default, unless otherwise specified
-# 2024-01-16: switch back to archspec with NESSI for now
-export EESSI_USE_ARCHDETECT="${EESSI_USE_ARCHDETECT:=0}"
-export EESSI_USE_ARCHSPEC="${EESSI_USE_ARCHSPEC:=1}"
+export EESSI_USE_ARCHDETECT="${EESSI_USE_ARCHDETECT:=1}"
+export EESSI_USE_ARCHSPEC="${EESSI_USE_ARCHSPEC:=0}"


### PR DESCRIPTION
Enabled using archdetect. Requires an update of the init scripts in the CVMFS repo.