### PR TITLE
{2023.06}[system] foss/2023a

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - foss-2023a.eb


### PR DESCRIPTION
Adds `foss/2023a` toolchain. This is one of the major toolchains being populated in `software.eessi.io`.

Modules to be installed:

```
32 out of 34 required modules missing:

* GCCcore/12.3.0 (GCCcore-12.3.0.eb)
* GCC/12.3.0 (GCC-12.3.0.eb)
* pkgconf/1.9.5-GCCcore-12.3.0 (pkgconf-1.9.5-GCCcore-12.3.0.eb)
* FFTW/3.3.10-GCC-12.3.0 (FFTW-3.3.10-GCC-12.3.0.eb)
* Perl/5.36.1-GCCcore-12.3.0 (Perl-5.36.1-GCCcore-12.3.0.eb)
* numactl/2.0.16-GCCcore-12.3.0 (numactl-2.0.16-GCCcore-12.3.0.eb)
* UnZip/6.0-GCCcore-12.3.0 (UnZip-6.0-GCCcore-12.3.0.eb)
* UCX/1.14.1-GCCcore-12.3.0 (UCX-1.14.1-GCCcore-12.3.0.eb)
* libxml2/2.11.4-GCCcore-12.3.0 (libxml2-2.11.4-GCCcore-12.3.0.eb)
* cURL/8.0.1-GCCcore-12.3.0 (cURL-8.0.1-GCCcore-12.3.0.eb)
* libevent/2.1.12-GCCcore-12.3.0 (libevent-2.1.12-GCCcore-12.3.0.eb)
* libarchive/3.6.2-GCCcore-12.3.0 (libarchive-3.6.2-GCCcore-12.3.0.eb)
* CMake/3.26.3-GCCcore-12.3.0 (CMake-3.26.3-GCCcore-12.3.0.eb)
* libfabric/1.18.0-GCCcore-12.3.0 (libfabric-1.18.0-GCCcore-12.3.0.eb)
* libffi/3.4.4-GCCcore-12.3.0 (libffi-3.4.4-GCCcore-12.3.0.eb)
* make/4.4.1-GCCcore-12.3.0 (make-4.4.1-GCCcore-12.3.0.eb)
* Tcl/8.6.13-GCCcore-12.3.0 (Tcl-8.6.13-GCCcore-12.3.0.eb)
* SQLite/3.42.0-GCCcore-12.3.0 (SQLite-3.42.0-GCCcore-12.3.0.eb)
* Python/3.11.3-GCCcore-12.3.0 (Python-3.11.3-GCCcore-12.3.0.eb)
* BLIS/0.9.0-GCC-12.3.0 (BLIS-0.9.0-GCC-12.3.0.eb)
* OpenBLAS/0.3.23-GCC-12.3.0 (OpenBLAS-0.3.23-GCC-12.3.0.eb)
* FlexiBLAS/3.3.1-GCC-12.3.0 (FlexiBLAS-3.3.1-GCC-12.3.0.eb)
* xorg-macros/1.20.0-GCCcore-12.3.0 (xorg-macros-1.20.0-GCCcore-12.3.0.eb)
* libpciaccess/0.17-GCCcore-12.3.0 (libpciaccess-0.17-GCCcore-12.3.0.eb)
* hwloc/2.9.1-GCCcore-12.3.0 (hwloc-2.9.1-GCCcore-12.3.0.eb)
* PMIx/4.2.4-GCCcore-12.3.0 (PMIx-4.2.4-GCCcore-12.3.0.eb)
* UCC/1.2.0-GCCcore-12.3.0 (UCC-1.2.0-GCCcore-12.3.0.eb)
* OpenMPI/4.1.5-GCC-12.3.0 (OpenMPI-4.1.5-GCC-12.3.0.eb)
* gompi/2023a (gompi-2023a.eb)
* FFTW.MPI/3.3.10-gompi-2023a (FFTW.MPI-3.3.10-gompi-2023a.eb)
* ScaLAPACK/2.2.0-gompi-2023a-fb (ScaLAPACK-2.2.0-gompi-2023a-fb.eb)
* foss/2023a (foss-2023a.eb)
```