### PR TITLE
{2023.06}[foss/2022b] GLib/2.75.0

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/test-pilot.nessi.no.yml
+++ b/.github/workflows/test-pilot.nessi.no.yml
@@ -19,7 +19,7 @@ jobs:
         - x86_64/generic
     steps:
         - name: Check out software-layer repository
-          uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+          uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
         - name: Mount NESSI CernVM-FS repository
           uses: cvmfs-contrib/github-action-cvmfs@d4641d0d591c9a5c3be23835ced2fb648b44c04b # v3.1

--- a/.github/workflows/test-pilot.nessi.no.yml
+++ b/.github/workflows/test-pilot.nessi.no.yml
@@ -22,7 +22,7 @@ jobs:
           uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
         - name: Mount NESSI CernVM-FS repository
-          uses: cvmfs-contrib/github-action-cvmfs@d4641d0d591c9a5c3be23835ced2fb648b44c04b # v3.1
+          uses: cvmfs-contrib/github-action-cvmfs@55899ca74cf78ab874bdf47f5a804e47c198743c # v4.0
           with:
               cvmfs_config_package: https://github.com/NorESSI/filesystem-layer/releases/download/latest/cvmfs-config-nessi_latest_all.deb
               cvmfs_http_proxy: DIRECT

--- a/.github/workflows/test_eessi_container_script.yml
+++ b/.github/workflows/test_eessi_container_script.yml
@@ -22,7 +22,7 @@ jobs:
         #- save
     steps:
         - name: Check out software-layer repository
-          uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+          uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
         - name: install Apptainer
           run: |

--- a/.github/workflows/test_licenses.yml
+++ b/.github/workflows/test_licenses.yml
@@ -11,7 +11,7 @@ jobs:
           uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
         - name: set up Python
-          uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
+          uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
           with:
             python-version: '3.9'
 

--- a/.github/workflows/test_licenses.yml
+++ b/.github/workflows/test_licenses.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
         - name: Check out software-layer repository
-          uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+          uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
         - name: set up Python
           uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
     steps:
     - name: checkout
-      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: set up Python
       uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: set up Python
-      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
+      uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: ${{matrix.python}}
         architecture: x64

--- a/.github/workflows/tests_archdetect.yml
+++ b/.github/workflows/tests_archdetect.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Mount NESSI CernVM-FS repository
-      uses: cvmfs-contrib/github-action-cvmfs@d4641d0d591c9a5c3be23835ced2fb648b44c04b # v3.1
+      uses: cvmfs-contrib/github-action-cvmfs@55899ca74cf78ab874bdf47f5a804e47c198743c # v4.0
       with:
           cvmfs_config_package: https://github.com/NorESSI/filesystem-layer/releases/download/latest/cvmfs-config-nessi_latest_all.deb
           cvmfs_http_proxy: DIRECT

--- a/.github/workflows/tests_archdetect.yml
+++ b/.github/workflows/tests_archdetect.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
     steps:
     - name: checkout
-      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Mount NESSI CernVM-FS repository
       uses: cvmfs-contrib/github-action-cvmfs@d4641d0d591c9a5c3be23835ced2fb648b44c04b # v3.1

--- a/.github/workflows/tests_init.yml
+++ b/.github/workflows/tests_init.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
     steps:
     - name: checkout
-      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: set up Python
       uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0

--- a/.github/workflows/tests_init.yml
+++ b/.github/workflows/tests_init.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: set up Python
-      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
+      uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: ${{matrix.python}}
         architecture: x64

--- a/.github/workflows/tests_readme.yml
+++ b/.github/workflows/tests_readme.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
         - name: Check out software-layer repository
-          uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+          uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
         - name: verify if README.md is consistent with EESSI_VERSION from init/eessi_defaults
           run: |

--- a/.github/workflows/tests_scripts.yml
+++ b/.github/workflows/tests_scripts.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: checkout
-      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: install Apptainer
       run: |

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - GLib-2.75.0-GCCcore-12.2.0.eb


### PR DESCRIPTION
Failed previously on `eX3 / aarch64/generic`. Try on `eX3` and `AWS`.

Modules to be installed:

```
4 out of 25 required modules missing:

* Ninja/1.11.1-GCCcore-12.2.0 (Ninja-1.11.1-GCCcore-12.2.0.eb)
* PCRE2/10.40-GCCcore-12.2.0 (PCRE2-10.40-GCCcore-12.2.0.eb)
* Meson/0.64.0-GCCcore-12.2.0 (Meson-0.64.0-GCCcore-12.2.0.eb)
* GLib/2.75.0-GCCcore-12.2.0 (GLib-2.75.0-GCCcore-12.2.0.eb)
```