### PR TITLE
{2023.06}[foss/2023a] SciPy-bundle/2023.07

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - foss-2023a.eb
+  - SciPy-bundle-2023.07-gfbf-2023a.eb


### PR DESCRIPTION
Add SciPy-bundle/2023.07.

Missing modules:

```
21 out of 40 required modules missing:

* expat/2.5.0-GCCcore-12.3.0 (expat-2.5.0-GCCcore-12.3.0.eb)
* Ninja/1.11.1-GCCcore-12.3.0 (Ninja-1.11.1-GCCcore-12.3.0.eb)
* hatchling/1.18.0-GCCcore-12.3.0 (hatchling-1.18.0-GCCcore-12.3.0.eb)
* scikit-build/0.17.6-GCCcore-12.3.0 (scikit-build-0.17.6-GCCcore-12.3.0.eb)
* Eigen/3.4.0-GCCcore-12.3.0 (Eigen-3.4.0-GCCcore-12.3.0.eb)
* Meson/1.1.1-GCCcore-12.3.0 (Meson-1.1.1-GCCcore-12.3.0.eb)
* git/2.41.0-GCCcore-12.3.0-nodocs (git-2.41.0-GCCcore-12.3.0-nodocs.eb)
* flit/3.9.0-GCCcore-12.3.0 (flit-3.9.0-GCCcore-12.3.0.eb)
* Catch2/2.13.9-GCCcore-12.3.0 (Catch2-2.13.9-GCCcore-12.3.0.eb)
* virtualenv/20.23.1-GCCcore-12.3.0 (virtualenv-20.23.1-GCCcore-12.3.0.eb)
* setuptools-rust/1.6.0-GCCcore-12.3.0 (setuptools-rust-1.6.0-GCCcore-12.3.0.eb)
* patchelf/0.18.0-GCCcore-12.3.0 (patchelf-0.18.0-GCCcore-12.3.0.eb)
* Rust/1.70.0-GCCcore-12.3.0 (Rust-1.70.0-GCCcore-12.3.0.eb)
* cffi/1.15.1-GCCcore-12.3.0 (cffi-1.15.1-GCCcore-12.3.0.eb)
* cryptography/41.0.1-GCCcore-12.3.0 (cryptography-41.0.1-GCCcore-12.3.0.eb)
* poetry/1.5.1-GCCcore-12.3.0 (poetry-1.5.1-GCCcore-12.3.0.eb)
* Python-bundle-PyPI/2023.06-GCCcore-12.3.0 (Python-bundle-PyPI-2023.06-GCCcore-12.3.0.eb)
* pybind11/2.11.1-GCCcore-12.3.0 (pybind11-2.11.1-GCCcore-12.3.0.eb)
* gfbf/2023a (gfbf-2023a.eb)
* hypothesis/6.82.0-GCCcore-12.3.0 (hypothesis-6.82.0-GCCcore-12.3.0.eb)
* SciPy-bundle/2023.07-gfbf-2023a (SciPy-bundle-2023.07-gfbf-2023a.eb)
```

