### PR TITLE
{2023.06}[system] foss/2023b

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -1,0 +1,3 @@
+easyconfigs:
+  - GCC-13.2.0.eb
+  - foss-2023b.eb


### PR DESCRIPTION
Trying to build foss/2023b.


```
32 out of 34 required modules missing:

* GCCcore/13.2.0 (GCCcore-13.2.0.eb)
* GCC/13.2.0 (GCC-13.2.0.eb)
* pkgconf/2.0.3-GCCcore-13.2.0 (pkgconf-2.0.3-GCCcore-13.2.0.eb)
* FFTW/3.3.10-GCC-13.2.0 (FFTW-3.3.10-GCC-13.2.0.eb)
* Perl/5.38.0-GCCcore-13.2.0 (Perl-5.38.0-GCCcore-13.2.0.eb)
* numactl/2.0.16-GCCcore-13.2.0 (numactl-2.0.16-GCCcore-13.2.0.eb)
* UnZip/6.0-GCCcore-13.2.0 (UnZip-6.0-GCCcore-13.2.0.eb)
* UCX/1.15.0-GCCcore-13.2.0 (UCX-1.15.0-GCCcore-13.2.0.eb)
* libxml2/2.11.5-GCCcore-13.2.0 (libxml2-2.11.5-GCCcore-13.2.0.eb)
* cURL/8.3.0-GCCcore-13.2.0 (cURL-8.3.0-GCCcore-13.2.0.eb)
* libevent/2.1.12-GCCcore-13.2.0 (libevent-2.1.12-GCCcore-13.2.0.eb)
* libarchive/3.7.2-GCCcore-13.2.0 (libarchive-3.7.2-GCCcore-13.2.0.eb)
* CMake/3.27.6-GCCcore-13.2.0 (CMake-3.27.6-GCCcore-13.2.0.eb)
* libfabric/1.19.0-GCCcore-13.2.0 (libfabric-1.19.0-GCCcore-13.2.0.eb)
* libffi/3.4.4-GCCcore-13.2.0 (libffi-3.4.4-GCCcore-13.2.0.eb)
* make/4.4.1-GCCcore-13.2.0 (make-4.4.1-GCCcore-13.2.0.eb)
* Tcl/8.6.13-GCCcore-13.2.0 (Tcl-8.6.13-GCCcore-13.2.0.eb)
* SQLite/3.43.1-GCCcore-13.2.0 (SQLite-3.43.1-GCCcore-13.2.0.eb)
* Python/3.11.5-GCCcore-13.2.0 (Python-3.11.5-GCCcore-13.2.0.eb)
* BLIS/0.9.0-GCC-13.2.0 (BLIS-0.9.0-GCC-13.2.0.eb)
* OpenBLAS/0.3.24-GCC-13.2.0 (OpenBLAS-0.3.24-GCC-13.2.0.eb)
* FlexiBLAS/3.3.1-GCC-13.2.0 (FlexiBLAS-3.3.1-GCC-13.2.0.eb)
* xorg-macros/1.20.0-GCCcore-13.2.0 (xorg-macros-1.20.0-GCCcore-13.2.0.eb)
* libpciaccess/0.17-GCCcore-13.2.0 (libpciaccess-0.17-GCCcore-13.2.0.eb)
* hwloc/2.9.2-GCCcore-13.2.0 (hwloc-2.9.2-GCCcore-13.2.0.eb)
* PMIx/4.2.6-GCCcore-13.2.0 (PMIx-4.2.6-GCCcore-13.2.0.eb)
* UCC/1.2.0-GCCcore-13.2.0 (UCC-1.2.0-GCCcore-13.2.0.eb)
* OpenMPI/4.1.6-GCC-13.2.0 (OpenMPI-4.1.6-GCC-13.2.0.eb)
* gompi/2023b (gompi-2023b.eb)
* FFTW.MPI/3.3.10-gompi-2023b (FFTW.MPI-3.3.10-gompi-2023b.eb)
* ScaLAPACK/2.2.0-gompi-2023b-fb (ScaLAPACK-2.2.0-gompi-2023b-fb.eb)
* foss/2023b (foss-2023b.eb)
```