### PR TITLE
{2023.06}[foss/2023a] OpenFOAM V11

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -1,2 +1,6 @@
 easyconfigs:
   - foss-2023a.eb
+  - OpenFOAM-11-foss-2023a.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19545
+      options:
+        from-pr: 19545


### PR DESCRIPTION
Trying to build OpenFOAM V11:

```
9 out of 140 required modules missing:

* CGAL/5.6-GCCcore-12.3.0 (CGAL-5.6-GCCcore-12.3.0.eb)
* ffnvcodec/12.0.16.0 (ffnvcodec-12.0.16.0.eb)
* x264/20230226-GCCcore-12.3.0 (x264-20230226-GCCcore-12.3.0.eb)
* SDL2/2.28.2-GCCcore-12.3.0 (SDL2-2.28.2-GCCcore-12.3.0.eb)
* Yasm/1.3.0-GCCcore-12.3.0 (Yasm-1.3.0-GCCcore-12.3.0.eb)
* x265/3.5-GCCcore-12.3.0 (x265-3.5-GCCcore-12.3.0.eb)
* FFmpeg/6.0-GCCcore-12.3.0 (FFmpeg-6.0-GCCcore-12.3.0.eb)
* ParaView/5.11.2-foss-2023a (ParaView-5.11.2-foss-2023a.eb)
* OpenFOAM/11-foss-2023a (OpenFOAM-11-foss-2023a.eb)

```

Maybe it needs more?
```
18 out of 113 required modules missing:

* METIS/5.1.0-GCCcore-12.3.0 (METIS-5.1.0-GCCcore-12.3.0.eb)
* CGAL/5.6-GCCcore-12.3.0 (CGAL-5.6-GCCcore-12.3.0.eb)
* libgd/2.3.3-GCCcore-12.3.0 (libgd-2.3.3-GCCcore-12.3.0.eb)
* libcerf/2.3-GCCcore-12.3.0 (libcerf-2.3-GCCcore-12.3.0.eb)
* Lua/5.4.6-GCCcore-12.3.0 (Lua-5.4.6-GCCcore-12.3.0.eb)
* netCDF/4.9.2-gompi-2023a (netCDF-4.9.2-gompi-2023a.eb)
* SCOTCH/7.0.3-gompi-2023a (SCOTCH-7.0.3-gompi-2023a.eb)
* ffnvcodec/12.0.16.0 (ffnvcodec-12.0.16.0.eb)
* Pango/1.50.14-GCCcore-12.3.0 (Pango-1.50.14-GCCcore-12.3.0.eb)
* x264/20230226-GCCcore-12.3.0 (x264-20230226-GCCcore-12.3.0.eb)
* LAME/3.100-GCCcore-12.3.0 (LAME-3.100-GCCcore-12.3.0.eb)
* SDL2/2.28.2-GCCcore-12.3.0 (SDL2-2.28.2-GCCcore-12.3.0.eb)
* Yasm/1.3.0-GCCcore-12.3.0 (Yasm-1.3.0-GCCcore-12.3.0.eb)
* x265/3.5-GCCcore-12.3.0 (x265-3.5-GCCcore-12.3.0.eb)
* FFmpeg/6.0-GCCcore-12.3.0 (FFmpeg-6.0-GCCcore-12.3.0.eb)
* ParaView/5.11.2-foss-2023a (ParaView-5.11.2-foss-2023a.eb)
* gnuplot/5.4.8-GCCcore-12.3.0 (gnuplot-5.4.8-GCCcore-12.3.0.eb)
* OpenFOAM/11-foss-2023a (OpenFOAM-11-foss-2023a.eb)
```