### PR TITLE
{2023.06}[foss/2023a] X11 V20230603

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -1,3 +1,4 @@
 easyconfigs:
   - foss-2023a.eb
   - SciPy-bundle-2023.07-gfbf-2023a.eb
+  - X11-20230603-GCCcore-12.3.0.eb


### PR DESCRIPTION
Trying to build X11-foss/2023a:

Missing modules :
```
8 out of 25 required modules missing:

* Bison/3.8.2-GCCcore-12.3.0 (Bison-3.8.2-GCCcore-12.3.0.eb)
* libiconv/1.17-GCCcore-12.3.0 (libiconv-1.17-GCCcore-12.3.0.eb)
* libpng/1.6.39-GCCcore-12.3.0 (libpng-1.6.39-GCCcore-12.3.0.eb)
* Brotli/1.0.9-GCCcore-12.3.0 (Brotli-1.0.9-GCCcore-12.3.0.eb)
* Doxygen/1.9.7-GCCcore-12.3.0 (Doxygen-1.9.7-GCCcore-12.3.0.eb)
* freetype/2.13.0-GCCcore-12.3.0 (freetype-2.13.0-GCCcore-12.3.0.eb)
* fontconfig/2.14.2-GCCcore-12.3.0 (fontconfig-2.14.2-GCCcore-12.3.0.eb)
* X11/20230603-GCCcore-12.3.0 (X11-20230603-GCCcore-12.3.0.eb)

```