### PR TITLE
{2023.06}[foss/2023a] BAGEL V1.2.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -2,3 +2,4 @@ easyconfigs:
   - foss-2023a.eb
   - SciPy-bundle-2023.07-gfbf-2023a.eb
   - X11-20230603-GCCcore-12.3.0.eb
+  - BAGEL-1.2.2-foss-2023a.eb


### PR DESCRIPTION
Trying to build BAGEL/1.2.2 - foss/2023a
```
7 out of 41 required modules missing:

BAGEL/1.2.2-foss-2023a.lua
Boost/1.82.0-GCC-12.3.0.lua
gzip/1.12-GCCcore-12.3.0.lua
ICU/73.2-GCCcore-12.3.0.lua
libxc/6.2.2-GCC-12.3.0.lua
lz4/1.9.4-GCCcore-12.3.0.lua
zstd/1.5.5-GCCcore-12.3.0.lua
```