### PR TITLE
{2023.06}[foss/2022a] Stacks v2.62

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2022a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2022a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - Stacks-2.62-foss-2022a.eb


### PR DESCRIPTION
Adding Stacks/2.62 as a demo PR.

SPDX: `GPL-3.0-only`

Missing packages:

```
1 out of 38 required modules missing:

* Stacks/2.62-foss-2022a (Stacks-2.62-foss-2022a.eb)
```

