### PR TITLE
{2023.06}[foss/2023a] ESPResSo V4.2.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.7.2-2021a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.7.2-2021a.yml
@@ -21,7 +21,8 @@ easyconfigs:
         options:
           from-pr: 18446
   - WRF-4.3-foss-2021a-dmpar.eb
-  - Yambo-5.1.1-foss-2021a.eb:
-        options:
-          from-pr: 18905
+  # The eaysconfig was used before the PR was merged.The new PR changes fail to deploy
+  # - Yambo-5.1.1-foss-2021a.eb:
+  #     options:
+  #       from-pr: 18905
       

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -3,3 +3,7 @@ easyconfigs:
   - SciPy-bundle-2023.07-gfbf-2023a.eb
   - X11-20230603-GCCcore-12.3.0.eb
   - BAGEL-1.2.2-foss-2023a.eb
+  - ESPResSo-4.2.1-foss-2023a.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19592    
+      options:
+        from-pr: 19592


### PR DESCRIPTION
Trying to build ESPResSo V4.2.1- foss/2023a :

```
BeautifulSoup/4.12.2-GCCcore-12.3.0.lua
Boost.MPI/1.82.0-gompi-2023a.lua
ESPResSo/4.2.1-foss-2023a.lua
GSL/2.7-GCC-12.3.0.lua
HDF5/1.14.0-gompi-2023a.lua
IPython/8.14.0-GCCcore-12.3.0.lua
libdrm/2.4.115-GCCcore-12.3.0.lua
libglvnd/1.6.0-GCCcore-12.3.0.lua
libsodium/1.0.18-GCCcore-12.3.0.lua
libunwind/1.6.2-GCCcore-12.3.0.lua
libxslt/1.1.38-GCCcore-12.3.0.lua
LLVM/16.0.6-GCCcore-12.3.0.lua
lxml/4.9.2-GCCcore-12.3.0.lua
Mako/1.2.4-GCCcore-12.3.0.lua
Mesa/23.1.4-GCCcore-12.3.0.lua
OpenPGM/5.2.122-GCCcore-12.3.0.lua
Pint/0.23-GCCcore-12.3.0.lua
Szip/2.1.1-GCCcore-12.3.0.lua
typing-extensions/4.9.0-GCCcore-12.3.0.lua
ZeroMQ/4.3.4-GCCcore-12.3.0.lua
```
NOTE: The missing modules for aarch64 have in addition the ones in #264 .