### PR TITLE
{2023.06}[foss/2023a] TensorFlow v2.13.0

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -7,3 +7,4 @@ easyconfigs:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19592    
       options:
         from-pr: 19592
+  - TensorFlow-2.13.0-foss-2023a.eb


### PR DESCRIPTION
SPDX license identifier: `Apache-2.0`

Missing modules:

```
20 out of 81 required modules missing:

* Zip/3.0-GCCcore-12.3.0 (Zip-3.0-GCCcore-12.3.0.eb)
* dill/0.3.7-GCCcore-12.3.0 (dill-0.3.7-GCCcore-12.3.0.eb)
* Bazel/6.3.1-GCCcore-12.3.0 (Bazel-6.3.1-GCCcore-12.3.0.eb)
* double-conversion/3.3.0-GCCcore-12.3.0 (double-conversion-3.3.0-GCCcore-12.3.0.eb)
* flatbuffers-python/23.5.26-GCCcore-12.3.0 (flatbuffers-python-23.5.26-GCCcore-12.3.0.eb)
* flatbuffers/23.5.26-GCCcore-12.3.0 (flatbuffers-23.5.26-GCCcore-12.3.0.eb)
* giflib/5.2.1-GCCcore-12.3.0 (giflib-5.2.1-GCCcore-12.3.0.eb)
* pkgconfig/1.5.5-GCCcore-12.3.0-python (pkgconfig-1.5.5-GCCcore-12.3.0-python.eb)
* JsonCpp/1.9.5-GCCcore-12.3.0 (JsonCpp-1.9.5-GCCcore-12.3.0.eb)
* NASM/2.16.01-GCCcore-12.3.0 (NASM-2.16.01-GCCcore-12.3.0.eb)
* libjpeg-turbo/2.1.5.1-GCCcore-12.3.0 (libjpeg-turbo-2.1.5.1-GCCcore-12.3.0.eb)
* nsync/1.26.0-GCCcore-12.3.0 (nsync-1.26.0-GCCcore-12.3.0.eb)
* mpi4py/3.1.4-gompi-2023a (mpi4py-3.1.4-gompi-2023a.eb)
* h5py/3.9.0-foss-2023a (h5py-3.9.0-foss-2023a.eb)
* snappy/1.1.10-GCCcore-12.3.0 (snappy-1.1.10-GCCcore-12.3.0.eb)
* Abseil/20230125.3-GCCcore-12.3.0 (Abseil-20230125.3-GCCcore-12.3.0.eb)
* protobuf/24.0-GCCcore-12.3.0 (protobuf-24.0-GCCcore-12.3.0.eb)
* protobuf-python/4.24.0-GCCcore-12.3.0 (protobuf-python-4.24.0-GCCcore-12.3.0.eb)
* RE2/2023-08-01-GCCcore-12.3.0 (RE2-2023-08-01-GCCcore-12.3.0.eb)
* TensorFlow/2.13.0-foss-2023a (TensorFlow-2.13.0-foss-2023a.eb)
```
