### PR TITLE
{2023.06}[foss/2023b] SciPy-bundle/2023.11, netCDF/4.9.2 and matplotlib/3.8.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -1,2 +1,9 @@
 easyconfigs:
   - foss-2023b.eb
+  - SciPy-bundle-2023.11-gfbf-2023b.eb
+  - netCDF-4.9.2-gompi-2023b.eb:
+      options:
+        from-pr: 19534
+  - matplotlib-3.8.2-gfbf-2023b.eb:
+      options:
+        from-pr: 19552


### PR DESCRIPTION
SPDX license identifiers:
- SciPy-bundle/2023.11 $\rightarrow$ `BSD-3-Clause` for SciPy
- netCDF/4.9.2 $\rightarrow$ `NetCDF` (https://www.unidata.ucar.edu/software/netcdf/copyright.html)
- matplotlib/3.8.2 $\rightarrow$ custom (https://github.com/matplotlib/matplotlib/blob/main/LICENSE/LICENSE)

Missing modules:
```
44 out of 65 required modules missing:

* libpng/1.6.40-GCCcore-13.2.0 (libpng-1.6.40-GCCcore-13.2.0.eb)
* expat/2.5.0-GCCcore-13.2.0 (expat-2.5.0-GCCcore-13.2.0.eb)
* Ninja/1.11.1-GCCcore-13.2.0 (Ninja-1.11.1-GCCcore-13.2.0.eb)
* hatchling/1.18.0-GCCcore-13.2.0 (hatchling-1.18.0-GCCcore-13.2.0.eb)
* scikit-build/0.17.6-GCCcore-13.2.0 (scikit-build-0.17.6-GCCcore-13.2.0.eb)
* cppy/1.2.1-GCCcore-13.2.0 (cppy-1.2.1-GCCcore-13.2.0.eb)
* Meson/1.2.3-GCCcore-13.2.0 (Meson-1.2.3-GCCcore-13.2.0.eb)
* git/2.42.0-GCCcore-13.2.0 (git-2.42.0-GCCcore-13.2.0.eb)
* flit/3.9.0-GCCcore-13.2.0 (flit-3.9.0-GCCcore-13.2.0.eb)
* Qhull/2020.2-GCCcore-13.2.0 (Qhull-2020.2-GCCcore-13.2.0.eb)
* Eigen/3.4.0-GCCcore-13.2.0 (Eigen-3.4.0-GCCcore-13.2.0.eb)
* Brotli/1.1.0-GCCcore-13.2.0 (Brotli-1.1.0-GCCcore-13.2.0.eb)
* freetype/2.13.2-GCCcore-13.2.0 (freetype-2.13.2-GCCcore-13.2.0.eb)
* virtualenv/20.24.6-GCCcore-13.2.0 (virtualenv-20.24.6-GCCcore-13.2.0.eb)
* Catch2/2.13.9-GCCcore-13.2.0 (Catch2-2.13.9-GCCcore-13.2.0.eb)
* NASM/2.16.01-GCCcore-13.2.0 (NASM-2.16.01-GCCcore-13.2.0.eb)
* Bison/3.8.2-GCCcore-13.2.0 (Bison-3.8.2-GCCcore-13.2.0.eb)
* libjpeg-turbo/3.0.1-GCCcore-13.2.0 (libjpeg-turbo-3.0.1-GCCcore-13.2.0.eb)
* setuptools-rust/1.8.0-GCCcore-13.2.0 (setuptools-rust-1.8.0-GCCcore-13.2.0.eb)
* jbigkit/2.1-GCCcore-13.2.0 (jbigkit-2.1-GCCcore-13.2.0.eb)
* patchelf/0.18.0-GCCcore-13.2.0 (patchelf-0.18.0-GCCcore-13.2.0.eb)
* Rust/1.73.0-GCCcore-13.2.0 (Rust-1.73.0-GCCcore-13.2.0.eb)
* cffi/1.15.1-GCCcore-13.2.0 (cffi-1.15.1-GCCcore-13.2.0.eb)
* fontconfig/2.14.2-GCCcore-13.2.0 (fontconfig-2.14.2-GCCcore-13.2.0.eb)
* libiconv/1.17-GCCcore-13.2.0 (libiconv-1.17-GCCcore-13.2.0.eb)
* cryptography/41.0.5-GCCcore-13.2.0 (cryptography-41.0.5-GCCcore-13.2.0.eb)
* Doxygen/1.9.8-GCCcore-13.2.0 (Doxygen-1.9.8-GCCcore-13.2.0.eb)
* poetry/1.6.1-GCCcore-13.2.0 (poetry-1.6.1-GCCcore-13.2.0.eb)
* Python-bundle-PyPI/2023.10-GCCcore-13.2.0 (Python-bundle-PyPI-2023.10-GCCcore-13.2.0.eb)
* hypothesis/6.90.0-GCCcore-13.2.0 (hypothesis-6.90.0-GCCcore-13.2.0.eb)
* pybind11/2.11.1-GCCcore-13.2.0 (pybind11-2.11.1-GCCcore-13.2.0.eb)
* meson-python/0.15.0-GCCcore-13.2.0 (meson-python-0.15.0-GCCcore-13.2.0.eb)
* libdeflate/1.19-GCCcore-13.2.0 (libdeflate-1.19-GCCcore-13.2.0.eb)
* gzip/1.13-GCCcore-13.2.0 (gzip-1.13-GCCcore-13.2.0.eb)
* gfbf/2023b (gfbf-2023b.eb)
* SciPy-bundle/2023.11-gfbf-2023b (SciPy-bundle-2023.11-gfbf-2023b.eb)
* lz4/1.9.4-GCCcore-13.2.0 (lz4-1.9.4-GCCcore-13.2.0.eb)
* X11/20231019-GCCcore-13.2.0 (X11-20231019-GCCcore-13.2.0.eb)
* zstd/1.5.5-GCCcore-13.2.0 (zstd-1.5.5-GCCcore-13.2.0.eb)
* Tk/8.6.13-GCCcore-13.2.0 (Tk-8.6.13-GCCcore-13.2.0.eb)
* LibTIFF/4.6.0-GCCcore-13.2.0 (LibTIFF-4.6.0-GCCcore-13.2.0.eb)
* Tkinter/3.11.5-GCCcore-13.2.0 (Tkinter-3.11.5-GCCcore-13.2.0.eb)
* Pillow/10.2.0-GCCcore-13.2.0 (Pillow-10.2.0-GCCcore-13.2.0.eb)
* matplotlib/3.8.2-gfbf-2023b (matplotlib-3.8.2-gfbf-2023b.eb)
```

