### PR TITLE
{2023.06}[foss/2023a] Qt5 v5.15.10

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -7,3 +7,4 @@ easyconfigs:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19592    
       options:
         from-pr: 19592
+  - Qt5-5.15.10-GCCcore-12.3.0.eb


### PR DESCRIPTION
SPDX license identifier: `LGPL-3.0-only`

Missing packages:

```
14 out of 55 required modules missing:

* PCRE2/10.42-GCCcore-12.3.0 (PCRE2-10.42-GCCcore-12.3.0.eb)
* re2c/3.1-GCCcore-12.3.0 (re2c-3.1-GCCcore-12.3.0.eb)
* GLib/2.77.1-GCCcore-12.3.0 (GLib-2.77.1-GCCcore-12.3.0.eb)
* graphite2/1.3.14-GCCcore-12.3.0 (graphite2-1.3.14-GCCcore-12.3.0.eb)
* pixman/0.42.2-GCCcore-12.3.0 (pixman-0.42.2-GCCcore-12.3.0.eb)
* cairo/1.17.8-GCCcore-12.3.0 (cairo-1.17.8-GCCcore-12.3.0.eb)
* GObject-Introspection/1.76.1-GCCcore-12.3.0 (GObject-Introspection-1.76.1-GCCcore-12.3.0.eb)
* HarfBuzz/5.3.1-GCCcore-12.3.0 (HarfBuzz-5.3.1-GCCcore-12.3.0.eb)
* NSPR/4.35-GCCcore-12.3.0 (NSPR-4.35-GCCcore-12.3.0.eb)
* NSS/3.89.1-GCCcore-12.3.0 (NSS-3.89.1-GCCcore-12.3.0.eb)
* JasPer/4.0.0-GCCcore-12.3.0 (JasPer-4.0.0-GCCcore-12.3.0.eb)
* nodejs/18.17.1-GCCcore-12.3.0 (nodejs-18.17.1-GCCcore-12.3.0.eb)
* libGLU/9.0.3-GCCcore-12.3.0 (libGLU-9.0.3-GCCcore-12.3.0.eb)
* Qt5/5.15.10-GCCcore-12.3.0 (Qt5-5.15.10-GCCcore-12.3.0.eb)
```