### PR TITLE
{2023.06}[foss/2023a] R v4.3.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -9,3 +9,4 @@ easyconfigs:
         from-pr: 19592
   - TensorFlow-2.13.0-foss-2023a.eb
   - Qt5-5.15.10-GCCcore-12.3.0.eb
+  - R-4.3.2-gfbf-2023a.eb


### PR DESCRIPTION
SPDX license identifier: `GPL-2.0-only`

Missing packages:

```
8 out of 63 required modules missing:

* jbigkit/2.1-GCCcore-12.3.0 (jbigkit-2.1-GCCcore-12.3.0.eb)
* libdeflate/1.18-GCCcore-12.3.0 (libdeflate-1.18-GCCcore-12.3.0.eb)
* LibTIFF/4.5.0-GCCcore-12.3.0 (LibTIFF-4.5.0-GCCcore-12.3.0.eb)
* Tk/8.6.13-GCCcore-12.3.0 (Tk-8.6.13-GCCcore-12.3.0.eb)
* PCRE/8.45-GCCcore-12.3.0 (PCRE-8.45-GCCcore-12.3.0.eb)
* libgit2/1.7.1-GCCcore-12.3.0 (libgit2-1.7.1-GCCcore-12.3.0.eb)
* FriBidi/1.0.12-GCCcore-12.3.0 (FriBidi-1.0.12-GCCcore-12.3.0.eb)
* R/4.3.2-gfbf-2023a (R-4.3.2-gfbf-2023a.eb)
```

