### PR TITLE
{2023.06}[foss/2023a] app mix 1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -18,3 +18,21 @@ easyconfigs:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19545
       options:
         from-pr: 19545
+  - CDO-2.2.2-gompi-2023a.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19735
+      options:
+        from-pr: 19735
+  - PyTorch-2.1.2-foss-2023a.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19573
+      options:
+        from-pr: 19573
+  - scikit-learn-1.3.1-gfbf-2023a.eb
+  - at-spi2-core-2.49.91-GCCcore-12.3.0.eb
+  - LHAPDF-6.5.4-GCC-12.3.0.eb:
+  - LoopTools-2.15-GCC-12.3.0.eb:
+  - Rivet-3.1.9-gompi-2023a-HepMC3-3.2.6.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19679
+      options:
+        from-pr: 19679
+  - ALL-0.9.2-foss-2023a.eb:
+  - OSU-Micro-Benchmarks-7.1-1-gompi-2023a.eb


### PR DESCRIPTION
SPDX license identifiers:
  - `CDO-2.2.2-gompi-2023a.eb` $\rightarrow$ `BSD-3-Clause`
  - PyTorch-2.1.2-foss-2023a.eb $\rightarrow$ "BSD-style" see https://github.com/pytorch/pytorch/blob/main/LICENSE
  - scikit-learn-1.3.1-gfbf-2023a.eb $\rightarrow$ `BSD-3-Clause`
  - at-spi2-core-2.49.91-GCCcore-12.3.0.eb $\rightarrow$ `LGPL-2.1-only`
  - LHAPDF-6.5.4-GCC-12.3.0.eb $\rightarrow$ `GPL-3.0-only`
  - LoopTools-2.15-GCC-12.3.0.eb $\rightarrow$ `LGPL-3.0-only`
  - Rivet-3.1.9-gompi-2023a-HepMC3-3.2.6.eb $\rightarrow$ `GPL-3.0-only`
  - ALL-0.9.2-foss-2023a.eb $\rightarrow$ `BSD-3-Clause`
  - OSU-Micro-Benchmarks-7.1-1-gompi-2023a.eb $\rightarrow$ "BSD-style" see http://mvapich.cse.ohio-state.edu/static/media/mvapich/LICENSE-OMB.txt

Missing installations:
```
8 out of 49 required modules missing:

* ecBuild/3.8.0 (ecBuild-3.8.0.eb)
* googletest/1.13.0-GCCcore-12.3.0 (googletest-1.13.0-GCCcore-12.3.0.eb)
* UDUNITS/2.2.28-GCCcore-12.3.0 (UDUNITS-2.2.28-GCCcore-12.3.0.eb)
* libaec/1.0.6-GCCcore-12.3.0 (libaec-1.0.6-GCCcore-12.3.0.eb)
* nlohmann_json/3.11.2-GCCcore-12.3.0 (nlohmann_json-3.11.2-GCCcore-12.3.0.eb)
* PROJ/9.2.0-GCCcore-12.3.0 (PROJ-9.2.0-GCCcore-12.3.0.eb)
* ecCodes/2.31.0-gompi-2023a (ecCodes-2.31.0-gompi-2023a.eb)
* CDO/2.2.2-gompi-2023a (CDO-2.2.2-gompi-2023a.eb)

15 out of 97 required modules missing:

* libyaml/0.2.5-GCCcore-12.3.0 (libyaml-0.2.5-GCCcore-12.3.0.eb)
* PyYAML/6.0-GCCcore-12.3.0 (PyYAML-6.0-GCCcore-12.3.0.eb)
* GMP/6.2.1-GCCcore-12.3.0 (GMP-6.2.1-GCCcore-12.3.0.eb)
* MPFR/4.2.0-GCCcore-12.3.0 (MPFR-4.2.0-GCCcore-12.3.0.eb)
* pytest-shard/0.1.2-GCCcore-12.3.0 (pytest-shard-0.1.2-GCCcore-12.3.0.eb)
* pytest-flakefinder/1.1.0-GCCcore-12.3.0 (pytest-flakefinder-1.1.0-GCCcore-12.3.0.eb)
* pytest-rerunfailures/12.0-GCCcore-12.3.0 (pytest-rerunfailures-12.0-GCCcore-12.3.0.eb)
* expecttest/0.1.5-GCCcore-12.3.0 (expecttest-0.1.5-GCCcore-12.3.0.eb)
* networkx/3.1-gfbf-2023a (networkx-3.1-gfbf-2023a.eb)
* Z3/4.12.2-GCCcore-12.3.0-Python-3.11.3 (Z3-4.12.2-GCCcore-12.3.0-Python-3.11.3.eb)
* MPC/1.3.1-GCCcore-12.3.0 (MPC-1.3.1-GCCcore-12.3.0.eb)
* gmpy2/2.1.5-GCC-12.3.0 (gmpy2-2.1.5-GCC-12.3.0.eb)
* sympy/1.12-gfbf-2023a (sympy-1.12-gfbf-2023a.eb)
* Pillow/10.0.0-GCCcore-12.3.0 (Pillow-10.0.0-GCCcore-12.3.0.eb)
* PyTorch/2.1.2-foss-2023a (PyTorch-2.1.2-foss-2023a.eb)

1 out of 41 required modules missing:

* scikit-learn/1.3.1-gfbf-2023a (scikit-learn-1.3.1-gfbf-2023a.eb)

1 out of 32 required modules missing:

* at-spi2-core/2.49.91-GCCcore-12.3.0 (at-spi2-core-2.49.91-GCCcore-12.3.0.eb)

1 out of 11 required modules missing:

* LHAPDF/6.5.4-GCC-12.3.0 (LHAPDF-6.5.4-GCC-12.3.0.eb)

1 out of 3 required modules missing:

* LoopTools/2.15-GCC-12.3.0 (LoopTools-2.15-GCC-12.3.0.eb)

6 out of 34 required modules missing:

* siscone/3.0.6-GCCcore-12.3.0 (siscone-3.0.6-GCCcore-12.3.0.eb)
* YODA/1.9.9-GCC-12.3.0 (YODA-1.9.9-GCC-12.3.0.eb)
* HepMC3/3.2.6-GCC-12.3.0 (HepMC3-3.2.6-GCC-12.3.0.eb)
* fastjet/3.4.2-gompi-2023a (fastjet-3.4.2-gompi-2023a.eb)
* fastjet-contrib/1.053-gompi-2023a (fastjet-contrib-1.053-gompi-2023a.eb)
* Rivet/3.1.9-gompi-2023a-HepMC3-3.2.6 (Rivet-3.1.9-gompi-2023a-HepMC3-3.2.6.eb)

2 out of 77 required modules missing:

* VTK/9.3.0-foss-2023a (VTK-9.3.0-foss-2023a.eb)
* ALL/0.9.2-foss-2023a (ALL-0.9.2-foss-2023a.eb)

1 out of 19 required modules missing:

* OSU-Micro-Benchmarks/7.1-1-gompi-2023a (OSU-Micro-Benchmarks-7.1-1-gompi-2023a.eb)
```
