### PR TITLE
{2023.06}[foss/2023a] GROMACS V2023.4

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -36,3 +36,6 @@ easyconfigs:
         from-pr: 19679
   - ALL-0.9.2-foss-2023a.eb:
   - OSU-Micro-Benchmarks-7.1-1-gompi-2023a.eb
+  - GROMACS-2023.4-foss-2023a.eb:
+      options:
+        from-pr: 19728


### PR DESCRIPTION
Trying to add GROMACS V2023.4 :

```
missing modules :

* GROMACS/2023.4-foss-2023a (GROMACS-2023.4-foss-2023a.eb)
```