### PR TITLE
{2023.06}[foss/2021a] NCL v6.6.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2021a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2021a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - NCL-6.6.2-foss-2021a.eb


### PR DESCRIPTION
SPDX license identifier:

Missing packages:
```
24 out of 85 required modules missing:

* xproto/7.0.31-GCCcore-10.3.0 (xproto-7.0.31-GCCcore-10.3.0.eb)
* makedepend/1.0.6-GCCcore-10.3.0 (makedepend-1.0.6-GCCcore-10.3.0.eb)
* g2lib/3.2.0-GCCcore-10.3.0 (g2lib-3.2.0-GCCcore-10.3.0.eb)
* g2clib/1.6.3-GCCcore-10.3.0 (g2clib-1.6.3-GCCcore-10.3.0.eb)
* NASM/2.15.05-GCCcore-10.3.0 (NASM-2.15.05-GCCcore-10.3.0.eb)
* libjpeg-turbo/2.0.6-GCCcore-10.3.0 (libjpeg-turbo-2.0.6-GCCcore-10.3.0.eb)
* libtirpc/1.3.2-GCCcore-10.3.0 (libtirpc-1.3.2-GCCcore-10.3.0.eb)
* HDF/4.2.15-GCCcore-10.3.0 (HDF-4.2.15-GCCcore-10.3.0.eb)
* UDUNITS/2.2.28-GCCcore-10.3.0 (UDUNITS-2.2.28-GCCcore-10.3.0.eb)
* GEOS/3.9.1-GCC-10.3.0 (GEOS-3.9.1-GCC-10.3.0.eb)
* GSL/2.7-GCC-10.3.0 (GSL-2.7-GCC-10.3.0.eb)
* pixman/0.40.0-GCCcore-10.3.0 (pixman-0.40.0-GCCcore-10.3.0.eb)
* PCRE/8.44-GCCcore-10.3.0 (PCRE-8.44-GCCcore-10.3.0.eb)
* jbigkit/2.1-GCCcore-10.3.0 (jbigkit-2.1-GCCcore-10.3.0.eb)
* netCDF-C++4/4.3.1-gompi-2021a (netCDF-C++4-4.3.1-gompi-2021a.eb)
* PCRE2/10.36-GCCcore-10.3.0 (PCRE2-10.36-GCCcore-10.3.0.eb)
* GLib/2.68.2-GCCcore-10.3.0 (GLib-2.68.2-GCCcore-10.3.0.eb)
* cairo/1.16.0-GCCcore-10.3.0 (cairo-1.16.0-GCCcore-10.3.0.eb)
* ESMF/8.1.1-foss-2021a (ESMF-8.1.1-foss-2021a.eb)
* LibTIFF/4.2.0-GCCcore-10.3.0 (LibTIFF-4.2.0-GCCcore-10.3.0.eb)
* PROJ/8.0.1-GCCcore-10.3.0 (PROJ-8.0.1-GCCcore-10.3.0.eb)
* libgeotiff/1.6.0-GCCcore-10.3.0 (libgeotiff-1.6.0-GCCcore-10.3.0.eb)
* GDAL/3.3.0-foss-2021a (GDAL-3.3.0-foss-2021a.eb)
* NCL/6.6.2-foss-2021a (NCL-6.6.2-foss-2021a.eb)
```