### PR TITLE
{2023.06}[foss/2023a] GDAL V3.7.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -36,3 +36,4 @@ easyconfigs:
         from-pr: 19679
   - ALL-0.9.2-foss-2023a.eb:
   - OSU-Micro-Benchmarks-7.1-1-gompi-2023a.eb
+  - GDAL-3.7.1-foss-2023a.eb


### PR DESCRIPTION

Trying to build the software currently found on Fram(using foss/2023a or foss2023/b), on NESSI:
```
18 out of 98 required modules missing:

* GEOS/3.12.0-GCC-12.3.0 (GEOS-3.12.0-GCC-12.3.0.eb)
* libgeotiff/1.7.1-GCCcore-12.3.0 (libgeotiff-1.7.1-GCCcore-12.3.0.eb)
* libtirpc/1.3.3-GCCcore-12.3.0 (libtirpc-1.3.3-GCCcore-12.3.0.eb)
* HDF/4.2.16-2-GCCcore-12.3.0 (HDF-4.2.16-2-GCCcore-12.3.0.eb)
* CFITSIO/4.3.0-GCCcore-12.3.0 (CFITSIO-4.3.0-GCCcore-12.3.0.eb)
* json-c/0.16-GCCcore-12.3.0 (json-c-0.16-GCCcore-12.3.0.eb)
* Xerces-C++/3.2.4-GCCcore-12.3.0 (Xerces-C++-3.2.4-GCCcore-12.3.0.eb)
* Imath/3.1.7-GCCcore-12.3.0 (Imath-3.1.7-GCCcore-12.3.0.eb)
* OpenEXR/3.1.7-GCCcore-12.3.0 (OpenEXR-3.1.7-GCCcore-12.3.0.eb)
* arpack-ng/3.9.0-foss-2023a (arpack-ng-3.9.0-foss-2023a.eb)
* Armadillo/12.6.2-foss-2023a (Armadillo-12.6.2-foss-2023a.eb)
* Qhull/2020.2-GCCcore-12.3.0 (Qhull-2020.2-GCCcore-12.3.0.eb)
* LERC/4.0.0-GCCcore-12.3.0 (LERC-4.0.0-GCCcore-12.3.0.eb)
* Highway/1.0.4-GCCcore-12.3.0 (Highway-1.0.4-GCCcore-12.3.0.eb)
* Brunsli/0.1-GCCcore-12.3.0 (Brunsli-0.1-GCCcore-12.3.0.eb)
* OpenJPEG/2.5.0-GCCcore-12.3.0 (OpenJPEG-2.5.0-GCCcore-12.3.0.eb)
* SWIG/4.1.1-GCCcore-12.3.0 (SWIG-4.1.1-GCCcore-12.3.0.eb)
* GDAL/3.7.1-foss-2023a (GDAL-3.7.1-foss-2023a.eb)

```