### PR TITLE
{2023.06}[foss/2023a] GPAW V23.9.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -37,3 +37,4 @@ easyconfigs:
   - ALL-0.9.2-foss-2023a.eb:
   - OSU-Micro-Benchmarks-7.1-1-gompi-2023a.eb
   - GDAL-3.7.1-foss-2023a.eb
+  - GPAW-23.9.1-foss-2023a.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -46,4 +46,8 @@ easyconfigs:
   - VCFtools-0.1.16-GCC-12.3.0.eb
   - BEDTools-2.31.0-GCC-12.3.0.eb
   - PLUMED-2.9.0-foss-2023a.eb
+  - Z3-4.12.2-GCCcore-12.3.0.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20050
+      options:
+        from-pr: 20050
   - GPAW-23.9.1-foss-2023a.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -37,4 +37,7 @@ easyconfigs:
   - ALL-0.9.2-foss-2023a.eb:
   - OSU-Micro-Benchmarks-7.1-1-gompi-2023a.eb
   - GDAL-3.7.1-foss-2023a.eb
-  - GPAW-23.9.1-foss-2023a.eb
+  - GPAW-24.1.0-foss-2023a.eb:
+      options:
+        from-pr: 19525
+- GPAW-23.9.1-foss-2023a.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -46,8 +46,4 @@ easyconfigs:
   - VCFtools-0.1.16-GCC-12.3.0.eb
   - BEDTools-2.31.0-GCC-12.3.0.eb
   - PLUMED-2.9.0-foss-2023a.eb
-  - Z3-4.12.2-GCCcore-12.3.0.eb:
-      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20050
-      options:
-        from-pr: 20050
   - GPAW-23.9.1-foss-2023a.eb

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -226,7 +226,7 @@ def parse_hook_openblas_relax_lapack_tests_num_errors(ec, eprefix):
         raise EasyBuildError("OpenBLAS-specific hook triggered for non-OpenBLAS easyconfig?!")
 
 
-def parse_hook_pillow_simd_harcoded_paths(ec, eprefix):
+def parse_hook_Pillow_SIMD_harcoded_paths(ec, eprefix):
     # patch setup.py to prefix hardcoded /usr/* and /lib paths with value of %(sysroot) template
     # (which will be empty if EasyBuild is not configured to use an alternate sysroot);
     # see also https://gitlab.com/eessi/support/-/issues/9
@@ -606,9 +606,9 @@ def inject_gpu_property(ec):
 PARSE_HOOKS = {
     'CGAL': parse_hook_cgal_toolchainopts_precise,
     'fontconfig': parse_hook_fontconfig_add_fonts,
-    'GPAW': parse_hook_gpaw_hardcoded_path,
+    'GPAW': parse_hook_gpaw_harcoded_path,
     'OpenBLAS': parse_hook_openblas_relax_lapack_tests_num_errors,
-    'Pillow-SIMD' : parse_hook_pillow_simd_harcoded_paths,
+    'Pillow-SIMD' : parse_hook_Pillow_SIMD_harcoded_paths,
     'pybind11': parse_hook_pybind11_replace_catch2,
     'Qt5': parse_hook_qt5_check_qtwebengine_disable,
     'UCX': parse_hook_ucx_eprefix,

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -185,7 +185,7 @@ def parse_hook_fontconfig_add_fonts(ec, eprefix):
 
 
 def parse_hook_gpaw_harcoded_path(ec, eprefix):
-    # configure the siteconfig.py file + patch setup.py to prefix hardcoded /usr/* and /lib paths with value of %(sysroot) template
+    # configure the siteconfig.py file + patch setup.py to prefix hardcoded /usr/* path with value of %(sysroot) template
     # (which will be empty if EasyBuild is not configured to use an alternate sysroot);
     if ec.name == 'GPAW':
         ec.update('preinstallopts', """echo "fftw = True" > siteconfig.py && """) 

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -189,7 +189,6 @@ def parse_hook_gpaw_harcoded_path(ec, eprefix):
     # (which will be empty if EasyBuild is not configured to use an alternate sysroot);
     if ec.name == 'GPAW':
         ec.update('preinstallopts', """echo "fftw = True" > siteconfig.py && """) 
-        ec.update('preinstallopts', """echo "elpa = True" >> siteconfig.py && """) 
         ec.update('preinstallopts', """echo "libvdwxc = True" >> siteconfig.py && """) 
         ec.update('preinstallopts', """echo "scalapack = True" >> siteconfig.py && """) 
         ec.update('preinstallopts', """echo "libraries = ['xc', 'fftw3', 'scalapack', 'vdwxc', 'elpa']" >>  siteconfig.py && """)


### PR DESCRIPTION
GPAW is found on Saga, will try to build it on NESSI:
 license --> https://spdx.org/licenses/GPL-3.0-or-later.html
 ```
8 out of 89 required modules missing:


* GPAW-setups/0.9.20000 (GPAW-setups-0.9.20000.eb)
* Flask/2.3.3-GCCcore-12.3.0 (Flask-2.3.3-GCCcore-12.3.0.eb)
* scikit-build-core/0.5.0-GCCcore-12.3.0 (scikit-build-core-0.5.0-GCCcore-12.3.0.eb)
* spglib-python/2.1.0-gfbf-2023a (spglib-python-2.1.0-gfbf-2023a.eb)
* libvdwxc/0.4.0-foss-2023a (libvdwxc-0.4.0-foss-2023a.eb)
* ELPA/2023.05.001-foss-2023a (ELPA-2023.05.001-foss-2023a.eb)
* ASE/3.22.1-gfbf-2023a (ASE-3.22.1-gfbf-2023a.eb)
* GPAW/23.9.1-foss-2023a (GPAW-23.9.1-foss-2023a.eb)
 ```