### PR TITLE
{2023.06}[foss/2023a] dask V2023.9.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -37,3 +37,4 @@ easyconfigs:
   - ALL-0.9.2-foss-2023a.eb:
   - OSU-Micro-Benchmarks-7.1-1-gompi-2023a.eb
   - GDAL-3.7.1-foss-2023a.eb
+  - dask-2023.9.2-foss-2023a.eb


### PR DESCRIPTION
dask is found on Saga, will try to build it on NESSI:
```
9 out of 86 required modules missing:

* cppy/1.2.1-GCCcore-12.3.0 (cppy-1.2.1-GCCcore-12.3.0.eb)
* tornado/6.3.2-GCCcore-12.3.0 (tornado-6.3.2-GCCcore-12.3.0.eb)
* meson-python/0.13.2-GCCcore-12.3.0 (meson-python-0.13.2-GCCcore-12.3.0.eb)
* libwebp/1.3.1-GCCcore-12.3.0 (libwebp-1.3.1-GCCcore-12.3.0.eb)
* Pillow-SIMD/9.5.0-GCCcore-12.3.0 (Pillow-SIMD-9.5.0-GCCcore-12.3.0.eb)
* Tkinter/3.11.3-GCCcore-12.3.0 (Tkinter-3.11.3-GCCcore-12.3.0.eb)
* matplotlib/3.7.2-gfbf-2023a (matplotlib-3.7.2-gfbf-2023a.eb)
* bokeh/3.2.2-foss-2023a (bokeh-3.2.2-foss-2023a.eb)
* dask/2023.9.2-foss-2023a (dask-2023.9.2-foss-2023a.eb)
```