### PR TITLE
{2023.06}[GCC/12.3.0] Tools

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -41,6 +41,7 @@ easyconfigs:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19646
       options:
         from-pr: 19646
+  - dask-2023.9.2-foss-2023a.eb
   - SAMtools-1.18-GCC-12.3.0.eb
   - VCFtools-0.1.16-GCC-12.3.0.eb
   - BEDTools-2.31.0-GCC-12.3.0.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -41,3 +41,6 @@ easyconfigs:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19646
       options:
         from-pr: 19646
+  - SAMtools-1.18-GCC-12.3.0.eb
+  - VCFtools-0.1.16-GCC-12.3.0.eb
+  - BEDTools-2.31.0-GCC-12.3.0.eb

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -209,6 +209,18 @@ def parse_hook_openblas_relax_lapack_tests_num_errors(ec, eprefix):
         raise EasyBuildError("OpenBLAS-specific hook triggered for non-OpenBLAS easyconfig?!")
 
 
+def parse_hook_Pillow_SIMD_harcoded_paths(ec, eprefix):
+    # patch setup.py to prefix hardcoded /usr/* and /lib paths with value of %(sysroot) template
+    # (which will be empty if EasyBuild is not configured to use an alternate sysroot);
+    # see also https://gitlab.com/eessi/support/-/issues/9
+    if ec.name == 'Pillow-SIMD':
+        ec.update('preinstallopts', """sed -i 's@"/usr/@"%(sysroot)s/usr/@g' setup.py && """)
+        ec.update('preinstallopts', """sed -i 's@"/lib@"%(sysroot)s/lib@g' setup.py && """)
+        print_msg("Using custom configure options for %s: %s", ec.name, ec['preinstallopts'])
+    else:
+        raise EasyBuildError("Pillow-SIMD-specific hook triggered for non-Pillow-SIMD easyconfig?!")
+
+
 def parse_hook_pybind11_replace_catch2(ec, eprefix):
     """
     Replace Catch2 build dependency in pybind11 easyconfigs with one that doesn't use system toolchain.
@@ -578,6 +590,7 @@ PARSE_HOOKS = {
     'CGAL': parse_hook_cgal_toolchainopts_precise,
     'fontconfig': parse_hook_fontconfig_add_fonts,
     'OpenBLAS': parse_hook_openblas_relax_lapack_tests_num_errors,
+    'Pillow-SIMD' : parse_hook_Pillow_SIMD_harcoded_paths,
     'pybind11': parse_hook_pybind11_replace_catch2,
     'Qt5': parse_hook_qt5_check_qtwebengine_disable,
     'UCX': parse_hook_ucx_eprefix,


### PR DESCRIPTION
Tools found on Saga, will try to build it on NESSI:
`Lic` : 
BEDTools/SAMtools --> https://spdx.org/licenses/MIT.html
VCFtools --> https://spdx.org/licenses/LGPL-3.0-only.html

```
5 out of 19 required modules missing:

* HTSlib/1.18-GCC-12.3.0 (HTSlib-1.18-GCC-12.3.0.eb)
* SAMtools/1.18-GCC-12.3.0 (SAMtools-1.18-GCC-12.3.0.eb)
* VCFtools/0.1.16-GCC-12.3.0 (VCFtools-0.1.16-GCC-12.3.0.eb)
* BamTools/2.5.2-GCC-12.3.0 (BamTools-2.5.2-GCC-12.3.0.eb)
* BEDTools/2.31.0-GCC-12.3.0 (BEDTools-2.31.0-GCC-12.3.0.eb)
```