### PR TITLE
{2023.06}[foss/2023a] PLUMED V2.9.0

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -45,3 +45,4 @@ easyconfigs:
   - SAMtools-1.18-GCC-12.3.0.eb
   - VCFtools-0.1.16-GCC-12.3.0.eb
   - BEDTools-2.31.0-GCC-12.3.0.eb
+  - PLUMED-2.9.0-foss-2023a.eb


### PR DESCRIPTION
PLUMED is found on Fram, will try to build it on NESSI:
 license --> https://spdx.org/licenses/LGPL-3.0-only.html
 ```

2 out of 63 required modules missing:

* xxd/9.0.2112-GCCcore-12.3.0 (xxd-9.0.2112-GCCcore-12.3.0.eb)
* PLUMED/2.9.0-foss-2023a (PLUMED-2.9.0-foss-2023a.eb)
 ```
