### PR TITLE
Make check_missing_installations.sh against develop branch

### DIFF
--- a/check_missing_installations.sh
+++ b/check_missing_installations.sh
@@ -18,6 +18,14 @@ easystack=$1
 
 LOCAL_TMPDIR=$(mktemp -d)
 
+# Clone the develop branch of EasyBuild and use that to search for easyconfigs
+git clone -b develop https://github.com/easybuilders/easybuild-easyconfigs.git $LOCAL_TMPDIR/easyconfigs
+export EASYBUILD_ROBOT_PATHS=$LOCAL_TMPDIR/easyconfigs/easybuild/easyconfigs
+
+# All PRs used in EESSI are supposed to be merged, so we can strip out all cases of from-pr
+tmp_easystack=${LOCAL_TMPDIR}/$(basename ${easystack})
+grep -v from-pr ${easystack} > ${tmp_easystack}
+
 source $TOPDIR/scripts/utils.sh
 
 source $TOPDIR/configure_easybuild
@@ -27,7 +35,7 @@ ${EB:-eb} --show-config
 
 echo ">> Checking for missing installations in ${EASYBUILD_INSTALLPATH}..."
 eb_missing_out=$LOCAL_TMPDIR/eb_missing.out
-${EB:-eb} --easystack ${easystack} --missing 2>&1 | tee ${eb_missing_out}
+${EB:-eb} --easystack ${tmp_easystack} --missing 2>&1 | tee ${eb_missing_out}
 exit_code=${PIPESTATUS[0]}
 
 ok_msg="Command 'eb --missing ...' succeeded, analysing output..."

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -6,6 +6,7 @@ easyconfigs:
         from-pr: 19534
   - matplotlib-3.8.2-gfbf-2023b.eb:
       options:
+        from-pr: 19552
   - CDO-2.2.2-gompi-2023b.eb:
       options:
         from-pr: 19792 

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -6,4 +6,6 @@ easyconfigs:
         from-pr: 19534
   - matplotlib-3.8.2-gfbf-2023b.eb:
       options:
-        from-pr: 19552
+  - CDO-2.2.2-gompi-2023b.eb:
+      options:
+        from-pr: 19792 

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -7,6 +7,3 @@ easyconfigs:
   - matplotlib-3.8.2-gfbf-2023b.eb:
       options:
         from-pr: 19552
-  - CDO-2.2.2-gompi-2023b.eb:
-      options:
-        from-pr: 19792 


### PR DESCRIPTION
Check for missing installations against the develop branch of EasyBuild.