### PR TITLE
{2023.06}[foss/2022b] ImageMagick v7.1.0-53

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
@@ -1,3 +1,7 @@
 easyconfigs:
   - GLib-2.75.0-GCCcore-12.2.0.eb
   - Qt5-5.15.7-GCCcore-12.2.0.eb
+  - ImageMagick-7.1.0-53-GCCcore-12.2.0.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20086
+      options:
+        from-pr: 20086

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -184,6 +184,18 @@ def parse_hook_fontconfig_add_fonts(ec, eprefix):
         raise EasyBuildError("fontconfig-specific hook triggered for non-fontconfig easyconfig?!")
 
 
+def parse_hook_imagemagick_add_dependency(ec, eprefix):
+    """Add dependency for PCRE/8.45 for ImageMagick/7.1.0-37"""
+    if ec.name == 'ImageMagick':
+        if LooseVersion(ec.version) == LooseVersion('7.1.0-37'):
+            print_msg("Added dependency for PCRE/8.45 to %s/%s", ec.name, ec.version)
+            ec['dependencies'].append(('PCRE', '8.45'))
+        else:
+            print_msg("Not adding dependency for PRCE/8.45 to %s/%s", ec.name, ec.version)
+    else:
+        raise EasyBuildError("ImageMagick-specific hook triggered for non-ImageMagick easyconfig?!")
+
+
 def parse_hook_openblas_relax_lapack_tests_num_errors(ec, eprefix):
     """Relax number of failing numerical LAPACK tests for aarch64/* CPU targets for OpenBLAS < 0.3.23"""
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
@@ -589,6 +601,7 @@ def inject_gpu_property(ec):
 PARSE_HOOKS = {
     'CGAL': parse_hook_cgal_toolchainopts_precise,
     'fontconfig': parse_hook_fontconfig_add_fonts,
+    'ImageMagick': parse_hook_imagemagick_add_dependency,
     'OpenBLAS': parse_hook_openblas_relax_lapack_tests_num_errors,
     'Pillow-SIMD' : parse_hook_Pillow_SIMD_harcoded_paths,
     'pybind11': parse_hook_pybind11_replace_catch2,

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -191,7 +191,7 @@ def parse_hook_imagemagick_add_dependency(ec, eprefix):
             print_msg("Added dependency for PCRE/8.45 to %s/%s", ec.name, ec.version)
             ec['dependencies'].append(('PCRE', '8.45'))
         else:
-            print_msg("Not adding dependency for PRCE/8.45 to %s/%s", ec.name, ec.version)
+            print_msg("Not adding dependency for PCRE/8.45 to %s/%s", ec.name, ec.version)
     else:
         raise EasyBuildError("ImageMagick-specific hook triggered for non-ImageMagick easyconfig?!")
 


### PR DESCRIPTION
ImageMagick is a dependency for R-bundle.

SPDX identifier: `ImageMagick`

Missing installations:
```
14 out of 66 required modules missing:

* jbigkit/2.1-GCCcore-12.2.0 (jbigkit-2.1-GCCcore-12.2.0.eb)
* LittleCMS/2.14-GCCcore-12.2.0 (LittleCMS-2.14-GCCcore-12.2.0.eb)
* libdeflate/1.15-GCCcore-12.2.0 (libdeflate-1.15-GCCcore-12.2.0.eb)
* FriBidi/1.0.12-GCCcore-12.2.0 (FriBidi-1.0.12-GCCcore-12.2.0.eb)
* LibTIFF/4.4.0-GCCcore-12.2.0 (LibTIFF-4.4.0-GCCcore-12.2.0.eb)
* ATK/2.38.0-GCCcore-12.2.0 (ATK-2.38.0-GCCcore-12.2.0.eb)
* Pango/1.50.12-GCCcore-12.2.0 (Pango-1.50.12-GCCcore-12.2.0.eb)
* Gdk-Pixbuf/2.42.10-GCCcore-12.2.0 (Gdk-Pixbuf-2.42.10-GCCcore-12.2.0.eb)
* at-spi2-core/2.46.0-GCCcore-12.2.0 (at-spi2-core-2.46.0-GCCcore-12.2.0.eb)
* at-spi2-atk/2.38.0-GCCcore-12.2.0 (at-spi2-atk-2.38.0-GCCcore-12.2.0.eb)
* libepoxy/1.5.10-GCCcore-12.2.0 (libepoxy-1.5.10-GCCcore-12.2.0.eb)
* GTK3/3.24.35-GCCcore-12.2.0 (GTK3-3.24.35-GCCcore-12.2.0.eb)
* Ghostscript/10.0.0-GCCcore-12.2.0 (Ghostscript-10.0.0-GCCcore-12.2.0.eb)
* ImageMagick/7.1.0-53-GCCcore-12.2.0 (ImageMagick-7.1.0-53-GCCcore-12.2.0.eb)
```