### PR TITLE
{2023.06}[foss/2023a] Z3 v4.12.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -46,3 +46,9 @@ easyconfigs:
   - VCFtools-0.1.16-GCC-12.3.0.eb
   - BEDTools-2.31.0-GCC-12.3.0.eb
   - PLUMED-2.9.0-foss-2023a.eb
+  - Z3-4.12.2-GCCcore-12.3.0.eb:
+      options:
+        # The Z3 dependency of PyTorch had it's versionsuffix removed
+        # and we need to workaround the problem this creates,
+        # see https://github.com/EESSI/software-layer/pull/501 for details
+        from-pr: 20050


### PR DESCRIPTION
Add Z3/4.12.2 to work around an issue because the package's version suffix has been removed. See https://github.com/EESSI/software-layer/pull/501 for details.

SPDX license identifier: `MIT`

Missing packages:

```
1 out of 14 required modules missing:

* Z3/4.12.2-GCCcore-12.3.0 (Z3-4.12.2-GCCcore-12.3.0.eb)
```