### PR TITLE
{2023.06}[GCCcore/12.3.0] Perl-bundle-CPAN V5.36.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -57,4 +57,3 @@ easyconfigs:
       # This easyconfig is added to overcome the failing of check_missing_installations against the development branch
   - parallel-20230722-GCCcore-12.3.0.eb
   - Highway-1.0.4-GCCcore-12.3.0.eb
-  - Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -51,5 +51,5 @@ easyconfigs:
         # The Z3 dependency of PyTorch had it's versionsuffix removed
         # and we need to workaround the problem this creates,
         # see https://github.com/EESSI/software-layer/pull/501 for details
-  -  PAN-5.36.1-GCCcore-12.3.0.eb
-
+        from-pr: 20050
+  - Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -51,5 +51,5 @@ easyconfigs:
         # The Z3 dependency of PyTorch had it's versionsuffix removed
         # and we need to workaround the problem this creates,
         # see https://github.com/EESSI/software-layer/pull/501 for details
- -  PAN-5.36.1-GCCcore-12.3.0.eb
+  -  PAN-5.36.1-GCCcore-12.3.0.eb
 

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -51,4 +51,5 @@ easyconfigs:
         # The Z3 dependency of PyTorch had it's versionsuffix removed
         # and we need to workaround the problem this creates,
         # see https://github.com/EESSI/software-layer/pull/501 for details
-        from-pr: 20050
+ -  PAN-5.36.1-GCCcore-12.3.0.eb
+

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -36,3 +36,6 @@ easyconfigs:
         from-pr: 19451
   - OSU-Micro-Benchmarks-7.2-gompi-2023a-CUDA-12.1.1.eb
   - ABySS-2.3.7-foss-2023a.eb
+  - Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb:
+      options:     
+        from-pr: 20540


### PR DESCRIPTION
PLUMED is found on Fram, will try to build it on NESSI:
license  -->https://spdx.org/licenses/GPL-1.0-or-later.html

 ```

2 out of 7 required modules missing:

* groff/1.22.4-GCCcore-12.3.0 (groff-1.22.4-GCCcore-12.3.0.eb)
* Perl-bundle-CPAN/5.36.1-GCCcore-12.3.0 (Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb)
 ```


