### PR TITLE
{2023.06}[foss/2023a] R-bundle-CRAN 2023.12

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -57,4 +57,3 @@ easyconfigs:
       # This easyconfig is added to overcome the failing of check_missing_installations against the development branch
   - parallel-20230722-GCCcore-12.3.0.eb
   - Highway-1.0.4-GCCcore-12.3.0.eb
-  - R-bundle-CRAN-2023.12-foss-2023a.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -53,3 +53,4 @@ easyconfigs:
         # see https://github.com/EESSI/software-layer/pull/501 for details
         from-pr: 20050
   - GPAW-23.9.1-foss-2023a.eb
+  - R-bundle-CRAN-2023.12-foss-2023a.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -8,3 +8,4 @@ easyconfigs:
         from-pr: 19471
         include-easyblocks-from-pr: 3036
   - JupyterNotebook-7.0.2-GCCcore-12.3.0.eb
+  - R-bundle-CRAN-2023.12-foss-2023a.eb


### PR DESCRIPTION
Attempt to add `R-bundle-CRAN/2023.12` to `software.eessi.io/2023.06`. See also https://github.com/EESSI/software-layer/pull/428

License:
- ca. 1100 R packages $\rightarrow$ need automation to determine individual licenses

Missing installations:
```
18 out of 148 required modules missing:

* NLopt/2.7.1-GCCcore-12.3.0 (NLopt-2.7.1-GCCcore-12.3.0.eb)
* nettle/3.9.1-GCCcore-12.3.0 (nettle-3.9.1-GCCcore-12.3.0.eb)
* libogg/1.3.5-GCCcore-12.3.0 (libogg-1.3.5-GCCcore-12.3.0.eb)
* FLAC/1.4.2-GCCcore-12.3.0 (FLAC-1.4.2-GCCcore-12.3.0.eb)
* libvorbis/1.3.7-GCCcore-12.3.0 (libvorbis-1.3.7-GCCcore-12.3.0.eb)
* Xvfb/21.1.8-GCCcore-12.3.0 (Xvfb-21.1.8-GCCcore-12.3.0.eb)
* libopus/1.4-GCCcore-12.3.0 (libopus-1.4-GCCcore-12.3.0.eb)
* libsndfile/1.2.2-GCCcore-12.3.0 (libsndfile-1.2.2-GCCcore-12.3.0.eb)
* ATK/2.38.0-GCCcore-12.3.0 (ATK-2.38.0-GCCcore-12.3.0.eb)
* PostgreSQL/16.1-GCCcore-12.3.0 (PostgreSQL-16.1-GCCcore-12.3.0.eb)
* Gdk-Pixbuf/2.42.10-GCCcore-12.3.0 (Gdk-Pixbuf-2.42.10-GCCcore-12.3.0.eb)
* at-spi2-atk/2.38.0-GCCcore-12.3.0 (at-spi2-atk-2.38.0-GCCcore-12.3.0.eb)
* libepoxy/1.5.10-GCCcore-12.3.0 (libepoxy-1.5.10-GCCcore-12.3.0.eb)
* Wayland/1.22.0-GCCcore-12.3.0 (Wayland-1.22.0-GCCcore-12.3.0.eb)
* GTK3/3.24.37-GCCcore-12.3.0 (GTK3-3.24.37-GCCcore-12.3.0.eb)
* Ghostscript/10.01.2-GCCcore-12.3.0 (Ghostscript-10.01.2-GCCcore-12.3.0.eb)
* ImageMagick/7.1.1-15-GCCcore-12.3.0 (ImageMagick-7.1.1-15-GCCcore-12.3.0.eb)
* R-bundle-CRAN/2023.12-foss-2023a (R-bundle-CRAN-2023.12-foss-2023a.eb)
```