### PR TITLE
{2023.06}[foss/2023b] GROMACS V2024.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -7,3 +7,6 @@ easyconfigs:
   - matplotlib-3.8.2-gfbf-2023b.eb:
       options:
         from-pr: 19552
+  - GROMACS-2024.1-foss-2023b.eb:
+      options:
+        from-pr: 20102

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
@@ -19,3 +19,6 @@ easyconfigs:
   - EveryBeam-0.5.2-foss-2023b.eb
   - DP3-6.0-foss-2023b.eb
   - WSClean-3.4-foss-2023b.eb
+  - GROMACS-2024.1-foss-2023b.eb:
+      options:
+        from-pr: 20439

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -391,6 +391,21 @@ def pre_configure_hook(self, *args, **kwargs):
         PRE_CONFIGURE_HOOKS[self.name](self, *args, **kwargs)
 
 
+def pre_configure_hook_gromacs(self, *args, **kwargs):
+    """
+    Pre-configure hook for GROMACS:
+    - avoid building with SVE instructions on Neoverse V1 as workaround for failing tests,
+      see https://gitlab.com/gromacs/gromacs/-/issues/5057 + https://gitlab.com/eessi/support/-/issues/47
+    """
+    if self.name == 'GROMACS':
+        cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
+        if LooseVersion(self.version) <= LooseVersion('2024.1') and cpu_target == CPU_TARGET_NEOVERSE_V1:
+            self.cfg.update('configopts', '-DGMX_SIMD=ARM_NEON_ASIMD')
+            print_msg("Avoiding use of SVE instructions for GROMACS %s by using ARM_NEON_ASIMD as GMX_SIMD value", self.version)
+    else:
+        raise EasyBuildError("GROMACS-specific hook triggered for non-GROMACS easyconfig?!")
+
+
 def pre_configure_hook_openblas_optarch_generic(self, *args, **kwargs):
     """
     Pre-configure hook for OpenBLAS: add DYNAMIC_ARCH=1 to build/test/install options when using --optarch=GENERIC
@@ -724,6 +739,7 @@ POST_PREPARE_HOOKS = {
 }
 
 PRE_CONFIGURE_HOOKS = {
+    'GROMACS': pre_configure_hook_gromacs,
     'libfabric': pre_configure_hook_libfabric_disable_psm3_x86_64_generic,
     'MetaBAT': pre_configure_hook_metabat_filtered_zlib_dep,
     'OpenBLAS': pre_configure_hook_openblas_optarch_generic,

--- a/eessi-2023.06-known-issues.yml
+++ b/eessi-2023.06-known-issues.yml
@@ -19,6 +19,9 @@
   - FFTW.MPI-3.3.10-gompi-2023b:
       - issue: https://github.com/EESSI/software-layer/issues/325
       - info: "Flaky FFTW tests, random failures"
+  - GROMACS-2024.1-foss-2023b:
+      - issue: https://github.com/EESSI/software-layer/issues/557
+      - info: "SVE disabled due to known bug which causes test failures"
   - Highway-1.0.3-GCCcore-12.2.0.eb:
     - issue: https://github.com/EESSI/software-layer/issues/469
     - info: "failing SVE test due to wrong expected value"


### PR DESCRIPTION
Adding GROMACS 2024.1
Lic : https://spdx.org/licenses/LGPL-2.1-only.html
Sync with EESSI (PR499) 
```
3 out of 59 required modules missing:

* networkx/3.2.1-gfbf-2023b (networkx-3.2.1-gfbf-2023b.eb)
* mpi4py/3.1.5-gompi-2023b (mpi4py-3.1.5-gompi-2023b.eb)
* GROMACS/2024.1-foss-2023b (GROMACS-2024.1-foss-2023b.eb)
```