### PR TITLE
{2023.06}[GCCcore/13.2.0] libwebp V1.3.2, OpenJPEG V2.5.0, LittleCMS V2.15

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-001-system.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-001-system.yml
@@ -4,6 +4,6 @@ easyconfigs:
         from-pr: 19464
   - ReFrame-4.3.3.eb
   - GPAW-setups-24.1.0.eb:
-      # This easyconfig is added to overcome the failing CI tests against the development branch     
+      # This easyconfig is added to overcome the failing of check_missing_installations against the development branch     
       options:
         from-pr: 20117

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -54,4 +54,4 @@ easyconfigs:
         from-pr: 20050
   - GPAW-23.9.1-foss-2023a.eb
   - LittleCMS-2.15-GCCcore-12.3.0.eb
-      # This easyconfig is added to overcome the failing CI tests against the development branch
+      # This easyconfig is added to overcome the failing of check_missing_installations against the development branch

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -7,6 +7,6 @@ easyconfigs:
   - matplotlib-3.8.2-gfbf-2023b.eb:
       options:
         from-pr: 19552
-  - OpenJPEG-2.5.0-GCCcore-13.2.0.eb
   - libwebp-1.3.2-GCCcore-13.2.0.eb
+  - OpenJPEG-2.5.0-GCCcore-13.2.0.eb
   - LittleCMS-2.15-GCCcore-13.2.0.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -9,4 +9,4 @@ easyconfigs:
         from-pr: 19552
   - OpenJPEG-2.5.0-GCCcore-13.2.0.eb
   - libwebp-1.3.2-GCCcore-13.2.0.eb
-  - littleCMS-2.15-GCCcore-13.2.0.eb
+  - LittleCMS-2.15-GCCcore-13.2.0.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -7,3 +7,6 @@ easyconfigs:
   - matplotlib-3.8.2-gfbf-2023b.eb:
       options:
         from-pr: 19552
+  - OpenJPEG-2.5.0-GCCcore-13.2.0.eb
+  - libwebp-1.3.2-GCCcore-13.2.0.eb
+  - littleCMS-2.15-GCCcore-13.2.0.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -8,5 +8,8 @@ easyconfigs:
       options:
         from-pr: 19552
   - libwebp-1.3.2-GCCcore-13.2.0.eb
+      # This easyconfig is added to overcome the failing of check_missing_installations against the development branch    
   - OpenJPEG-2.5.0-GCCcore-13.2.0.eb
+      # This easyconfig is added to overcome the failing of check_missing_installations against the development branch
   - LittleCMS-2.15-GCCcore-13.2.0.eb
+      # This easyconfig is added to overcome the failing of check_missing_installations against the development branch


### PR DESCRIPTION
[easybuild/easyconfigs/p/Pillow/Pillow-10.2.0-GCCcore-13.2.0.eb](https://github.com/easybuilders/easybuild-easyconfigs/pull/20195/files#diff-48aff6bfce4a1c759d6a93c70f37a97c0a299a4c71bc2f27729f6c09855226ea) has been updated with additional dependencies which are being built in the current PR.

```
Missing packages :

* LittleCMS/2.15-GCCcore-13.2.0 (LittleCMS-2.15-GCCcore-13.2.0.eb) SPDX license identifier: MIT
* libwebp/1.3.2-GCCcore-13.2.0 (libwebp-1.3.2-GCCcore-13.2.0.eb)   SPDX license identifier: BSD License
* giflib/5.2.1-GCCcore-13.2.0 (giflib-5.2.1-GCCcore-13.2.0.eb) --> dependency of libwebp V1.3.2
* OpenJPEG/2.5.0-GCCcore-13.2.0 (OpenJPEG-2.5.0-GCCcore-13.2.0.eb) SPDX license identifier: BSD License
```