### PR TITLE
add `pre_test` hook for dealing with failing Highway tests

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -402,6 +402,16 @@ def pre_test_hook(self,*args, **kwargs):
         PRE_TEST_HOOKS[self.name](self, *args, **kwargs)
 
 
+def pre_test_hook_exclude_failing_test_Highway(self, *args, **kwargs):
+    """
+    Pre-test hook for Highway: exclude failing TestAllShiftRightLanes/SVE_256 test on neoverse_v1
+    cfr. https://github.com/EESSI/software-layer/issues/469
+    """
+    cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
+    if self.name == 'Highway' and self.version in ['1.0.3'] and cpu_target == CPU_TARGET_NEOVERSE_V1:
+        self.cfg['runtest'] += ' ARGS="-E TestAllShiftRightLanes/SVE_256"'
+
+
 def pre_test_hook_ignore_failing_tests_ESPResSo(self, *args, **kwargs):
     """
     Pre-test hook for ESPResSo: skip failing tests, tests frequently timeout due to known bugs in ESPResSo v4.2.1
@@ -642,6 +652,7 @@ PRE_CONFIGURE_HOOKS = {
 PRE_TEST_HOOKS = {
     'ESPResSo': pre_test_hook_ignore_failing_tests_ESPResSo,
     'FFTW.MPI': pre_test_hook_ignore_failing_tests_FFTWMPI,
+    'Highway': pre_test_hook_exclude_failing_test_Highway,
     'SciPy-bundle': pre_test_hook_ignore_failing_tests_SciPybundle,
     'netCDF': pre_test_hook_ignore_failing_tests_netCDF,
     'PyTorch': pre_test_hook_increase_max_failed_tests_arm_PyTorch,

--- a/eessi-2023.06-known-issues.yml
+++ b/eessi-2023.06-known-issues.yml
@@ -16,6 +16,9 @@
   - FFTW.MPI-3.3.10-gompi-2023b:
       - issue: https://github.com/EESSI/software-layer/issues/325
       - info: "Flaky FFTW tests, random failures"
+  - Highway-1.0.3-GCCcore-12.2.0.eb:
+    - issue: https://github.com/EESSI/software-layer/issues/469
+    - info: "failing SVE test due to wrong expected value"
   - netCDF-4.9.2-gompi-2023a.eb:
       - issue: https://github.com/EESSI/software-layer/issues/425
       - info: "netCDF intermittent test failures"


### PR DESCRIPTION
This is a PR to sync NESSI with EESSI. See #294 

Particularly this PR is for addressing `code` and `other` changes added to EESSI in https://github.com/EESSI/software-layer/pull/419

The `software` part added by this EESSI PR is not yet in NESSI. It can be handled later.

Thus, we don't need to build any software for this PR.