### PR TITLE
test case A for PR299

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -58,6 +58,6 @@ easyconfigs:
   # purpose of the following is to test one case in PR #299
   #   case is "build software with an un-merged EasyBuild easyconfig PR without
   #   the modifications of PR 299 which should lead to a FAILURE with unclear message"
-  - pyGAM-0.9.1-gfbf-2023a.eb
+  - pyGAM-0.9.1-gfbf-2023a.eb:
       options:
         from-pr: 20308

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -55,3 +55,9 @@ easyconfigs:
   - GPAW-23.9.1-foss-2023a.eb
   - LittleCMS-2.15-GCCcore-12.3.0.eb
       # This easyconfig is added to overcome the failing of check_missing_installations against the development branch
+  # purpose of the following is to test one case in PR #299
+  #   case is "build software with an un-merged EasyBuild easyconfig PR without
+  #   the modifications of PR 299 which should lead to a FAILURE with unclear message"
+  - pyGAM-0.9.1-gfbf-2023a.eb
+      options:
+        from-pr: 20308


### PR DESCRIPTION
This PR shall be used to test the case

___
build software with an un-merged EasyBuild easyconfig PR without the modifications of this PR (https://github.com/NorESSI/software-layer/pull/299) -> should lead to a FAILURE with unclear message
___

It uses the recent un-merged PR 20308 for an easy config (_{data}[gfbf/2023a] pyGAM v0.9.1_).

We need to check in the logs (slurm outfile) whether the build succeeded and then hopefully get an unclear error message nevertheless.