### PR TITLE
Always use LMOD_RC file, and make sure loading CUDA apps always works when building

### DIFF
--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -51,6 +51,11 @@ if [ -d ${eessi_version}/scripts ]; then
     find ${eessi_version}/scripts -type f | grep -v '/\.wh\.' >> ${files_list}
 fi
 
+# also include init, which is also copied by install_scripts.sh
+if [ -d ${eessi_version}/init ]; then
+    find ${eessi_version}/init -type f | grep -v '/\.wh\.' >> ${files_list}
+fi
+
 if [ -d ${eessi_version}/software/${os}/${cpu_arch_subdir}/modules ]; then
     # module files
     find ${eessi_version}/software/${os}/${cpu_arch_subdir}/modules -type f | grep -v '/\.wh\.' >> ${files_list}

--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -457,6 +457,12 @@ if [[ ${SETUP_NVIDIA} -eq 1 ]]; then
         mkdir -p ${EESSI_USR_LOCAL_CUDA}
         BIND_PATHS="${BIND_PATHS},${EESSI_VAR_LOG}:/var/log,${EESSI_USR_LOCAL_CUDA}:/usr/local/cuda"
         [[ ${VERBOSE} -eq 1 ]] && echo "BIND_PATHS=${BIND_PATHS}"
+        if [[ "${NVIDIA_MODE}" == "install" ]] ; then
+            # We need to "trick" our LMOD_RC file to allow us to load CUDA modules even without a CUDA driver
+            # (this works because we build within a container and the LMOD_RC recognises that)
+            touch ${EESSI_TMPDIR}/libcuda.so
+            export SINGULARITY_CONTAINLIBS="${EESSI_TMPDIR}/libcuda.so"
+        fi
     fi
 fi
 

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -50,6 +50,15 @@ if [ -d $EESSI_PREFIX ]; then
 
         show_msg "Using ${EESSI_SOFTWARE_SUBDIR} as software subdirectory."
         export EESSI_SOFTWARE_PATH=$EESSI_PREFIX/software/$EESSI_OS_TYPE/$EESSI_SOFTWARE_SUBDIR
+
+        # Configure our LMOD_RC file
+        export LMOD_RC="$EESSI_SOFTWARE_PATH/.lmod/lmodrc.lua"
+        if [ -f $LMOD_RC ]; then
+          show_msg "Found Lmod configuration file at $LMOD_RC"
+        else
+          error "Lmod configuration file not found at $LMOD_RC"
+        fi
+
         if [ ! -z $EESSI_BASIC_ENV ]; then
           show_msg "Only setting up basic environment, so we're done"
         elif [ -d $EESSI_SOFTWARE_PATH ]; then
@@ -74,13 +83,6 @@ if [ -d $EESSI_PREFIX ]; then
           else
             error "NESSI module path at $EESSI_MODULEPATH not found!"
             false
-          fi
-
-          export LMOD_RC="$EESSI_SOFTWARE_PATH/.lmod/lmodrc.lua"
-          if [ -f $LMOD_RC ]; then
-            show_msg "Found Lmod configuration file at $LMOD_RC"
-          else
-            error "Lmod configuration file not found at $LMOD_RC"
           fi
 
         else

--- a/install_scripts.sh
+++ b/install_scripts.sh
@@ -25,6 +25,35 @@ compare_and_copy() {
     fi
 }
 
+copy_files_by_list() {
+# Compares and copies listed files from a source to a target directory
+    if [ ! "$#" -ge 3 ]; then
+        echo "Usage of function: copy_files_by_list <source_dir> <destination_dir> <file_list>"
+        echo "Here, file_list is an (expanded) bash array"
+        echo "Example:"
+        echo "my_files=(file1 file2)"
+        echo 'copy_files_by_list /my/source /my/target "${my_files[@]}"'
+        return 1
+    fi
+    source_dir="$1"
+    target_dir="$2"
+    # Need to shift all arguments to the left twice. Then, rebuild the array with the rest of the arguments
+    shift
+    shift
+    file_list=("$@")
+
+    # Create target dir
+    mkdir -p ${target_dir}
+
+    # Copy from source to target
+    echo "Copying files: ${file_list[@]}"
+    echo "From directory: ${source_dir}"
+    echo "To directory: ${target_dir}"
+
+    for file in ${file_list[@]}; do
+        compare_and_copy ${source_dir}/${file} ${target_dir}/${file}
+    done
+}
 
 POSITIONAL_ARGS=()
 
@@ -54,28 +83,33 @@ set -- "${POSITIONAL_ARGS[@]}"
 
 TOPDIR=$(dirname $(realpath $0))
 
-# Subdirs for generic scripts
-SCRIPTS_DIR_SOURCE=${TOPDIR}/scripts  # Source dir
-SCRIPTS_DIR_TARGET=${INSTALL_PREFIX}/scripts  # Target dir
+# Copy for init directory
+init_files=(
+    bash eessi_archdetect.sh eessi_defaults eessi_environment_variables eessi_software_subdir_for_host.py
+    minimal_eessi_env README.md test.py
+)
+copy_files_by_list ${TOPDIR}/init ${INSTALL_PREFIX}/init "${init_files[@]}"
 
-# Create target dir
-mkdir -p ${SCRIPTS_DIR_TARGET}
+# Copy for the init/arch_specs directory
+arch_specs_files=(
+   eessi_arch_arm.spec eessi_arch_ppc.spec eessi_arch_x86.spec
+)
+copy_files_by_list ${TOPDIR}/init/arch_specs ${INSTALL_PREFIX}/init/arch_specs "${arch_specs_files[@]}"
 
-# Copy scripts into this prefix
-echo "copying scripts from ${SCRIPTS_DIR_SOURCE} to ${SCRIPTS_DIR_TARGET}"
-for file in utils.sh; do
-    compare_and_copy ${SCRIPTS_DIR_SOURCE}/${file} ${SCRIPTS_DIR_TARGET}/${file}
-done
-# Subdirs for GPU support
-NVIDIA_GPU_SUPPORT_DIR_SOURCE=${SCRIPTS_DIR_SOURCE}/gpu_support/nvidia  # Source dir
-NVIDIA_GPU_SUPPORT_DIR_TARGET=${SCRIPTS_DIR_TARGET}/gpu_support/nvidia  # Target dir
+# Copy for init/Magic_castle directory
+mc_files=(
+   bash eessi_python3
+)
+copy_files_by_list ${TOPDIR}/init/Magic_Castle ${INSTALL_PREFIX}/init/Magic_Castle "${mc_files[@]}"
 
-# Create target dir
-mkdir -p ${NVIDIA_GPU_SUPPORT_DIR_TARGET}
+# Copy for the scripts directory
+script_files=(
+    utils.sh
+)
+copy_files_by_list ${TOPDIR}/scripts ${INSTALL_PREFIX}/scripts "${script_files[@]}"
 
-# Copy files from this directory into the prefix
-# To be on the safe side, we dont do recursive copies, but we are explicitely copying each individual file we want to add
-echo "copying scripts from ${NVIDIA_GPU_SUPPORT_DIR_SOURCE} to ${NVIDIA_GPU_SUPPORT_DIR_TARGET}"
-for file in install_cuda_host_injections.sh link_nvidia_host_libraries.sh; do
-    compare_and_copy ${NVIDIA_GPU_SUPPORT_DIR_SOURCE}/${file} ${NVIDIA_GPU_SUPPORT_DIR_TARGET}/${file}
-done
+# Copy files for the scripts/gpu_support/nvidia directory
+nvidia_files=(
+    install_cuda_host_injections.sh link_nvidia_host_libraries.sh
+)
+copy_files_by_list ${TOPDIR}/scripts/gpu_support/nvidia ${INSTALL_PREFIX}/scripts/gpu_support/nvidia "${nvidia_files[@]}"


### PR DESCRIPTION
Simply uses the commit in https://github.com/EESSI/software-layer/pull/475

Need the following changes to `create_tarball.sh` (they were introduced in https://github.com/EESSI/software-layer/pull/496 and thus used in #306; the latter will be reduced after merging #307) or changes to `init` scripts won't be included in tarballs and those changes cannot be ingested via the standard procedure.

```diff
diff --git a/create_tarball.sh b/create_tarball.sh
index a619df9..2d77acf 100755
--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -51,6 +51,11 @@ if [ -d ${eessi_version}/scripts ]; then
     find ${eessi_version}/scripts -type f | grep -v '/\.wh\.' >> ${files_list}
 fi

+# also include init, which is also copied by install_scripts.sh
+if [ -d ${eessi_version}/init ]; then
+    find ${eessi_version}/init -type f | grep -v '/\.wh\.' >> ${files_list}
+fi
+
 if [ -d ${eessi_version}/software/${os}/${cpu_arch_subdir}/modules ]; then
     # module files
     find ${eessi_version}/software/${os}/${cpu_arch_subdir}/modules -type f | grep -v '/\.wh\.' >> ${files_list}
```

Need changes to `install_scripts.sh` as well. See commit https://github.com/NorESSI/software-layer/pull/307/commits/ecb936ebd8ae1ef990c744bfdb2c38aa72bcdd90

Also need changes to `ingest-tarball.sh` on the Stratum 0 (see https://github.com/EESSI/filesystem-layer/pull/186).