### PR TITLE
remove Lmod cache update

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -247,7 +247,7 @@ fi
 
 ### add packages here
 
-echo ">> Creating/updating Lmod cache..."
+echo ">> Creating/updating Lmod RC file..."
 export LMOD_CONFIG_DIR="${EASYBUILD_INSTALLPATH}/.lmod"
 lmod_rc_file="$LMOD_CONFIG_DIR/lmodrc.lua"
 lmodrc_changed=$(cat ${pr_diff} | grep '^+++' | cut -f2 -d' ' | sed 's@^[a-z]/@@g' | grep '^create_lmodrc.py$' > /dev/null; echo $?)

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -265,7 +265,5 @@ if [ ! -f "$lmod_sitepackage_file" ] || [ "${sitepackage_changed}" == '0' ]; the
     check_exit_code $? "$lmod_sitepackage_file created" "Failed to create $lmod_sitepackage_file"
 fi
 
-$TOPDIR/update_lmod_cache.sh ${EPREFIX} ${EASYBUILD_INSTALLPATH}
-
 echo ">> Cleaning up ${TMPDIR}..."
 rm -r ${TMPDIR}


### PR DESCRIPTION
Sync NESSI with EESSI (PR 512).

This removes the Lmod cache update. The functionality has been moved to the Stratum 0 (see https://github.com/EESSI/filesystem-layer/pull/175).

We test this first via #310
- if built tarballs don't include the Lmod cache updates
- if so, we can merge this PR and update #310