### PR TITLE
{2023.06}[foss/2023a] parallel v20230722 (also: test remove Lmod update cache)

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -55,3 +55,4 @@ easyconfigs:
   - GPAW-23.9.1-foss-2023a.eb
   - LittleCMS-2.15-GCCcore-12.3.0.eb
       # This easyconfig is added to overcome the failing of check_missing_installations against the development branch
+  - parallel-20230722-GCCcore-12.3.0.eb


### PR DESCRIPTION
This PR adds `parallel v20230722`. It also serves as a test for #309 

SPDX license identifier: `GPL-3.0-or-later`

Missing installations:
```
1 out of 3 required modules missing:

* parallel/20230722-GCCcore-12.3.0 (parallel-20230722-GCCcore-12.3.0.eb)
```

We process this PR as follows:
1. We build `parallel` and verify if the tarballs do no longer include the Lmod cache updates.
2. If so, we merge #309 first, and update this PR here.
3. Finally, we deploy the built tarballs and verify if the Lmod caches are updated on the Stratum 0 during the ingestion.