### PR TITLE
{2023.06}[system] EasyBuild v4.9.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-001-system.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-001-system.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - EasyBuild-4.9.1.eb:
+      options:
+        from-pr: 20299


### PR DESCRIPTION
PR to add EasyBuild 4.9.1

SPDX license identifier: `GPL-2.0-only`

Also used to verify if building still works after #312 has been merged.

Plus used as a trial for building some (or all) `aarch64/generic` software on AWS.
- That didn't work. See https://github.com/NorESSI/software-layer/pull/314#issuecomment-2048300664