### PR TITLE
{2023.06}[foss/2023a,foss/2023b] ignore fakeroot and do not remove packages & rebuild GCCcore 12.3.0 / 13.2.0

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -198,7 +198,9 @@ else
     REMOVAL_STEP_ARGS+=("--storage" "${STORAGE}")
     # add fakeroot option in order to be able to remove software, see:
     # https://github.com/EESSI/software-layer/issues/312
-    REMOVAL_STEP_ARGS+=("--fakeroot")
+    # CURRENTLY NOT SUPPORTED; software packages need to be removed from
+    # CernVM-FS repository first
+    # REMOVAL_STEP_ARGS+=("--fakeroot")
 
     # create tmp file for output of removal step
     removal_outerr=$(mktemp remove.outerr.XXXX)

--- a/easystacks/pilot.nessi.no/2023.06/rebuilds/20240412-eb-4.9.1-GCCcore-fix-aarch64-vectorization.yml
+++ b/easystacks/pilot.nessi.no/2023.06/rebuilds/20240412-eb-4.9.1-GCCcore-fix-aarch64-vectorization.yml
@@ -1,0 +1,12 @@
+# 2024-04-12
+# Rebuild GCCcore to fix a compiler bug in the tree-vectorizer
+# We encountered it in https://github.com/EESSI/software-layer/pull/479#issuecomment-1957091774
+# and https://github.com/EESSI/software-layer/pull/507#issuecomment-2011724613
+# Upstream issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111478
+# Upstream fix: https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=e5f1956498251a4973d52c8aad3faf34d0443169
+# Fix in EasyBuild https://github.com/easybuilders/easybuild-easyconfigs/pull/19974
+# https://github.com/easybuilders/easybuild-easyconfigs/pull/20218
+#   Both should be included with EB 4.9.1
+easyconfigs:
+  - GCCcore-12.3.0.eb:
+  - GCCcore-13.2.0.eb:

--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -74,6 +74,7 @@ display_help() {
   echo "  -c | --container IMG   - image file or URL defining the container to use"
   echo "                           [default: docker://ghcr.io/eessi/build-node:debian11]"
   echo "  -f | --fakeroot        - run the container with --fakeroot [default: false]"
+  echo "                           Note, currently this option is ignored."
   echo "  -g | --storage DIR     - directory space on host machine (used for"
   echo "                           temporary data) [default: 1. TMPDIR, 2. /tmp]"
   echo "  -h | --help            - display this usage information [default: false]"
@@ -143,7 +144,9 @@ while [[ $# -gt 0 ]]; do
 #      shift 1
 #      ;;
     -f|--fakeroot)
-      FAKEROOT=1
+      # Currently this argument is being ignored
+      echo "NOTE, '-f' and '--fakeroot' are currently being ignored."
+      # FAKEROOT=1
       shift 1
       ;;
     -g|--storage)


### PR DESCRIPTION
This PR serves two purposes:
1. allowing to rebuild packages following what EESSI implemented with (PR 488 and 518), see #312
   - NOTE, this requires a manual removal of the packages that shall be rebuild first. 
2. rebuild GCCcore/12.3.0 and GCCcore/13.2.0

The PR is processed in three stages:
1. Only test if the code modifications that ignore `fakeroot` ✅ and only report about packages to be removed work ✅.
2. Remove the packages from CernVM-FS. ✅ 
   - CI checking for missing installations failed afterwards
4. Rebuild ✅ and ingest them ✅.

SPDX license identifier: `GPL-3.0-or-later`