### PR TITLE
{2023.06}[foss/2022b,foss/2023a,foss/2023b] REBUILD OpenMPI v4.1.{4,5,6}

### DIFF
--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -145,31 +145,10 @@ local function eessi_cuda_enabled_load_hook(t)
     end
 end
 
-local function eessi_openmpi_load_hook(t)
-    -- disable smcuda BTL when loading OpenMPI module for aarch64/neoverse_v1,
-    -- to work around hang/crash due to bug in OpenMPI;
-    -- see https://gitlab.com/eessi/support/-/issues/41
-    local frameStk = require("FrameStk"):singleton()
-    local mt = frameStk:mt()
-    local moduleName = string.match(t.modFullName, "(.-)/")
-    local cpuTarget = os.getenv("EESSI_SOFTWARE_SUBDIR") or ""
-    if (moduleName == "OpenMPI") and (cpuTarget == "aarch64/neoverse_v1") then
-        local msg = "Adding '^smcuda' to $OMPI_MCA_btl to work around bug in OpenMPI"
-        LmodMessage(msg .. " (see https://gitlab.com/eessi/support/-/issues/41)")
-        local ompiMcaBtl = os.getenv("OMPI_MCA_btl")
-        if ompiMcaBtl == nil then
-            setenv("OMPI_MCA_btl", "^smcuda")
-        else
-            setenv("OMPI_MCA_btl", ompiMcaBtl .. ",^smcuda")
-        end
-    end
-end
-
 -- Combine both functions into a single one, as we can only register one function as load hook in lmod
 -- Also: make it non-local, so it can be imported and extended by other lmodrc files if needed
 function eessi_load_hook(t)
     eessi_cuda_enabled_load_hook(t)
-    eessi_openmpi_load_hook(t)
 end
 
 

--- a/easystacks/pilot.nessi.no/2023.06/rebuilds/20240413-eb-4.9.1-OpenMPI-4.1.x-fix-smcuda.yml
+++ b/easystacks/pilot.nessi.no/2023.06/rebuilds/20240413-eb-4.9.1-OpenMPI-4.1.x-fix-smcuda.yml
@@ -1,0 +1,10 @@
+# 2024-04-13
+# Rebuild all OpenMPI 4.1.x versions due to an issue with smcuda:
+# https://github.com/open-mpi/ompi/issues/12270
+# https://github.com/open-mpi/ompi/pull/12344
+# https://github.com/easybuilders/easybuild-easyconfigs/pull/19940
+#   Note, we don't need the easyconfig PR because it is included in EasyBuild 4.9.1
+easyconfigs:
+  - OpenMPI-4.1.4-GCC-12.2.0.eb:
+  - OpenMPI-4.1.5-GCC-12.3.0:
+  - OpenMPI-4.1.6-GCC-13.2.0:


### PR DESCRIPTION
This PR serves two purposes:
1. removing the Lmod `eessi_openmpi_load_hook` because it's not needed after OpenMPI has been rebuilt
2. rebuild `OpenMPI/4.1.{4,5,6}-GCC-{12.2.0,12.3.0,13.2.0}`
   - NOTE, this requires a manual removal of the packages that shall be rebuild first. 

The PR is processed in three stages:
1. Test if the code modifications that ignore `fakeroot` ✅, if script reports about packages to be removed (but it's not removing) ✅, if `SitePackage.lua` is being created (due to changed `create_lmodsitepackage.py` ✅, if all ReFrame tests succeed again (they did not at the end of #318) ✅ and if CI for missing installations succeeded before removing packages from CernVM-FS repository ✅.
2. Remove the packages from CernVM-FS. ✅ 
   - CI checking for missing installations failed afterwards ✅ 
4. Rebuild ✅ and ingest them ✅.

SPDX license identifier: `BSD-3-Clause`