### PR TITLE
{2023.06}[foss/2023a] BWA v0.7.17-20220923

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - BWA-0.7.17-20220923-GCCcore-12.3.0.eb


### PR DESCRIPTION
Syncing NESSI with EESSI (PR 468).

SPDX license identifier: `GPL-3.0-only`

Missing installations:
```
1 out of 3 required modules missing:

* BWA/0.7.17.20220923-GCCcore-12.3.0 (BWA-0.7.17.20220923-GCCcore-12.3.0.eb)
```