### PR TITLE
{2023.06}[foss/2022b] GDAL v3.6.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - GDAL-3.6.2-foss-2022b.eb


### PR DESCRIPTION
Syncing NESSI with EESSI (PR 419).

SPDX license identifier: MIT style license

Missing installations:
```
32 out of 90 required modules missing:

* Szip/2.1.1-GCCcore-12.2.0 (Szip-2.1.1-GCCcore-12.2.0.eb)
* GEOS/3.11.1-GCC-12.2.0 (GEOS-3.11.1-GCC-12.2.0.eb)
* PCRE/8.45-GCCcore-12.2.0 (PCRE-8.45-GCCcore-12.2.0.eb)
* googletest/1.12.1-GCCcore-12.2.0 (googletest-1.12.1-GCCcore-12.2.0.eb)
* nlohmann_json/3.11.2-GCCcore-12.2.0 (nlohmann_json-3.11.2-GCCcore-12.2.0.eb)
* PROJ/9.1.1-GCCcore-12.2.0 (PROJ-9.1.1-GCCcore-12.2.0.eb)
* libgeotiff/1.7.1-GCCcore-12.2.0 (libgeotiff-1.7.1-GCCcore-12.2.0.eb)
* HDF5/1.14.0-gompi-2022b (HDF5-1.14.0-gompi-2022b.eb)
* netCDF/4.9.0-gompi-2022b (netCDF-4.9.0-gompi-2022b.eb)
* hypothesis/6.68.2-GCCcore-12.2.0 (hypothesis-6.68.2-GCCcore-12.2.0.eb)
* libtirpc/1.3.3-GCCcore-12.2.0 (libtirpc-1.3.3-GCCcore-12.2.0.eb)
* HDF/4.2.15-GCCcore-12.2.0 (HDF-4.2.15-GCCcore-12.2.0.eb)
* CFITSIO/4.2.0-GCCcore-12.2.0 (CFITSIO-4.2.0-GCCcore-12.2.0.eb)
* giflib/5.2.1-GCCcore-12.2.0 (giflib-5.2.1-GCCcore-12.2.0.eb)
* Boost/1.81.0-GCC-12.2.0 (Boost-1.81.0-GCC-12.2.0.eb)
* json-c/0.16-GCCcore-12.2.0 (json-c-0.16-GCCcore-12.2.0.eb)
* Eigen/3.4.0-GCCcore-12.2.0 (Eigen-3.4.0-GCCcore-12.2.0.eb)
* Xerces-C++/3.2.4-GCCcore-12.2.0 (Xerces-C++-3.2.4-GCCcore-12.2.0.eb)
* Catch2/2.13.9-GCCcore-12.2.0 (Catch2-2.13.9-GCCcore-12.2.0.eb)
* pybind11/2.10.3-GCCcore-12.2.0 (pybind11-2.10.3-GCCcore-12.2.0.eb)
* Imath/3.1.6-GCCcore-12.2.0 (Imath-3.1.6-GCCcore-12.2.0.eb)
* OpenEXR/3.1.5-GCCcore-12.2.0 (OpenEXR-3.1.5-GCCcore-12.2.0.eb)
* gfbf/2022b (gfbf-2022b.eb)
* SciPy-bundle/2023.02-gfbf-2022b (SciPy-bundle-2023.02-gfbf-2022b.eb)
* arpack-ng/3.8.0-foss-2022b (arpack-ng-3.8.0-foss-2022b.eb)
* Armadillo/11.4.3-foss-2022b (Armadillo-11.4.3-foss-2022b.eb)
* Qhull/2020.2-GCCcore-12.2.0 (Qhull-2020.2-GCCcore-12.2.0.eb)
* LERC/4.0.0-GCCcore-12.2.0 (LERC-4.0.0-GCCcore-12.2.0.eb)
* Highway/1.0.3-GCCcore-12.2.0 (Highway-1.0.3-GCCcore-12.2.0.eb)
* Brunsli/0.1-GCCcore-12.2.0 (Brunsli-0.1-GCCcore-12.2.0.eb)
* OpenJPEG/2.5.0-GCCcore-12.2.0 (OpenJPEG-2.5.0-GCCcore-12.2.0.eb)
* GDAL/3.6.2-foss-2022b (GDAL-3.6.2-foss-2022b.eb)
```