### PR TITLE
{2023.06}[foss/2023a] LAMMPS v2Aug2023_update2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -1,3 +1,8 @@
 easyconfigs:
   - BWA-0.7.17-20220923-GCCcore-12.3.0.eb
-  - LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb
+  - LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19471
+      # see https://github.com/easybuilders/easybuild-easyblocks/pull/3036
+      options:
+        from-pr: 19471
+        include-easyblocks-from-pr: 3036

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - BWA-0.7.17-20220923-GCCcore-12.3.0.eb
+  - LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -316,7 +316,7 @@ def parse_hook_lammps_remove_deps_for_CI_aarch64(ec, *args, **kwargs):
             if build_option('optarch') == OPTARCH_GENERIC:
                 ec['kokkos_arch'] = 'ARMV80'
                 print_msg("Set kokkos_arch = 'ARMV80' (cpu family: %s, optarch: %s",
-                    os.geten('EESSI_CPU_FAMILY'), build_option('optarch'))
+                    os.getenv('EESSI_CPU_FAMILY'), build_option('optarch'))
     else:
         raise EasyBuildError("LAMMPS-specific hook triggered for non-LAMMPS easyconfig?!")
 

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -308,6 +308,15 @@ def parse_hook_lammps_remove_deps_for_CI_aarch64(ec, *args, **kwargs):
             # we need this hook because we check for missing installations for all CPU targets
             # on an x86_64 VM in GitHub Actions (so condition based on ARCH in LAMMPS easyconfig is always true)
             ec['dependencies'] = [dep for dep in ec['dependencies'] if dep[0] not in ('ScaFaCoS', 'tbb')]
+            # if the optarch is GENERIC we also set 'kokkos_arch' to 'ARMV80' (if not set the easyblock will
+            # run "python -c 'from archspec.cpu import host; print(host())'"
+            # which returns the host architecture which is then mapped to some
+            # identifier corresponding to the architecture; however, this may not
+            # be correct if we want to build for `aarch64/generic`
+            if build_option('optarch') == OPTARCH_GENERIC:
+                ec['kokkos_arch'] = 'ARMV80'
+                print_msg("Set kokkos_arch = 'ARMV80' (cpu family: %s, optarch: %s",
+                    os.geten('EESSI_CPU_FAMILY'), build_option('optarch'))
     else:
         raise EasyBuildError("LAMMPS-specific hook triggered for non-LAMMPS easyconfig?!")
 

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -308,14 +308,16 @@ def parse_hook_lammps_remove_deps_for_CI_aarch64(ec, *args, **kwargs):
             # we need this hook because we check for missing installations for all CPU targets
             # on an x86_64 VM in GitHub Actions (so condition based on ARCH in LAMMPS easyconfig is always true)
             ec['dependencies'] = [dep for dep in ec['dependencies'] if dep[0] not in ('ScaFaCoS', 'tbb')]
-            # if the optarch is GENERIC we also set 'kokkos_arch' to 'ARMV80' (if not set the easyblock will
-            # run "python -c 'from archspec.cpu import host; print(host())'"
-            # which returns the host architecture which is then mapped to some
-            # identifier corresponding to the architecture; however, this may not
-            # be correct if we want to build for `aarch64/generic`
+            # if optarch is GENERIC, we also set 'kokkos_arch' to 'ARMV80'
+            #   if not set the easyblock will run
+            #   "python -c 'from archspec.cpu import host; print(host())'"
+            #   which returns the host architecture which is then mapped to some
+            #   identifier corresponding to the architecture;
+            #   however, this may not be correct if we want to build for
+            #   `aarch64/generic`
             if build_option('optarch') == OPTARCH_GENERIC:
                 ec['kokkos_arch'] = 'ARMV80'
-                print_msg("Set kokkos_arch = 'ARMV80' (cpu family: %s, optarch: %s",
+                print_msg("Set kokkos_arch = 'ARMV80' (cpu family: %s, optarch: %s)",
                     os.getenv('EESSI_CPU_FAMILY'), build_option('optarch'))
     else:
         raise EasyBuildError("LAMMPS-specific hook triggered for non-LAMMPS easyconfig?!")


### PR DESCRIPTION
Syncing NESSI with EESSI (PRs 472 and 477).

SPDX license identifier: `GPL-2.0-only`

Missing installations:

```
5/7 (aarch64/x86_64) out of 99/101 required modules missing:

* archspec/0.2.1-GCCcore-12.3.0 (archspec-0.2.1-GCCcore-12.3.0.eb)
* Voro++/0.4.6-GCCcore-12.3.0 (Voro++-0.4.6-GCCcore-12.3.0.eb)
* kim-api/2.3.0-GCC-12.3.0 (kim-api-2.3.0-GCC-12.3.0.eb)
* MDI/1.4.26-gompi-2023a (MDI-1.4.26-gompi-2023a.eb)
* (x86_64 only) tbb/2021.11.0-GCCcore-12.3.0 (tbb-2021.11.0-GCCcore-12.3.0.eb)
* (x86_64 only) ScaFaCoS/1.0.4-foss-2023a (ScaFaCoS-1.0.4-foss-2023a.eb)
* LAMMPS/2Aug2023_update2-foss-2023a-kokkos (LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb)
```