### PR TITLE
{2023.06}[foss/2023a] PyQt5 v5.15.10

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -1,2 +1,7 @@
 easyconfigs:
   - BWA-0.7.17-20220923-GCCcore-12.3.0.eb
+  - matplotlib-3.7.2-gfbf-2023a.eb
+  - PyQt5-5.15.10-GCCcore-12.3.0.eb
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19554
+      #options:
+      #  from-pr: 19554

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -1,7 +1,3 @@
 easyconfigs:
   - BWA-0.7.17-20220923-GCCcore-12.3.0.eb
-  - matplotlib-3.7.2-gfbf-2023a.eb
   - PyQt5-5.15.10-GCCcore-12.3.0.eb
-      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19554
-      #options:
-      #  from-pr: 19554


### PR DESCRIPTION
Sync NESSI with EESSI (PR 476)
  - looks like matplotlib was already in the stack

SPDX license identifiers:
- ~matplotlib: _Matplotlib_ (BSD compatible)~
- PyQt5: `GPL-3`

Missing packages:
```
4 out of 72 required modules missing:

* PLY/3.11-GCCcore-12.3.0 (PLY-3.11-GCCcore-12.3.0.eb)
* SIP/6.8.1-GCCcore-12.3.0 (SIP-6.8.1-GCCcore-12.3.0.eb)
* PyQt-builder/1.15.4-GCCcore-12.3.0 (PyQt-builder-1.15.4-GCCcore-12.3.0.eb)
* PyQt5/5.15.10-GCCcore-12.3.0 (PyQt5-5.15.10-GCCcore-12.3.0.eb)
```