### PR TITLE
{2023.06}[foss/2023b] CDO v2.2.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -1,3 +1,3 @@
 easyconfigs:
   - GDAL-3.6.2-foss-2022b.eb
-  -  waLBerla-6.1-foss-2022b.eb
+  - waLBerla-6.1-foss-2022b.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - CDO-2.2.2-gompi-2023b.eb


### PR DESCRIPTION
Syn NESSI with EESSI (PR 492)

SPDX license identifier: `BSD-3-Clause`

Missing packages:
```
8 out of 52 required modules missing:

* JasPer/4.0.0-GCCcore-13.2.0 (JasPer-4.0.0-GCCcore-13.2.0.eb)
* googletest/1.14.0-GCCcore-13.2.0 (googletest-1.14.0-GCCcore-13.2.0.eb)
* UDUNITS/2.2.28-GCCcore-13.2.0 (UDUNITS-2.2.28-GCCcore-13.2.0.eb)
* libaec/1.0.6-GCCcore-13.2.0 (libaec-1.0.6-GCCcore-13.2.0.eb)
* nlohmann_json/3.11.3-GCCcore-13.2.0 (nlohmann_json-3.11.3-GCCcore-13.2.0.eb)
* PROJ/9.3.1-GCCcore-13.2.0 (PROJ-9.3.1-GCCcore-13.2.0.eb)
* ecCodes/2.31.0-gompi-2023b (ecCodes-2.31.0-gompi-2023b.eb)
* CDO/2.2.2-gompi-2023b (CDO-2.2.2-gompi-2023b.eb)
```