### PR TITLE
{2023.06}[foss/2023a] JupyterNotebook v7.0.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -7,3 +7,4 @@ easyconfigs:
       options:
         from-pr: 19471
         include-easyblocks-from-pr: 3036
+  - JupyterNotebook-7.0.2-GCCcore-12.3.0.eb


### PR DESCRIPTION
Syn NESSI with EESSI (PR 495).

SPDX license identifier: `BSD-3-Clause`

Missing packages:
```
5 out of 43 required modules missing:

* maturin/1.1.0-GCCcore-12.3.0 (maturin-1.1.0-GCCcore-12.3.0.eb)
* PyZMQ/25.1.1-GCCcore-12.3.0 (PyZMQ-25.1.1-GCCcore-12.3.0.eb)
* jupyter-server/2.7.2-GCCcore-12.3.0 (jupyter-server-2.7.2-GCCcore-12.3.0.eb)
* JupyterLab/4.0.5-GCCcore-12.3.0 (JupyterLab-4.0.5-GCCcore-12.3.0.eb)
* JupyterNotebook/7.0.2-GCCcore-12.3.0 (JupyterNotebook-7.0.2-GCCcore-12.3.0.eb)
```