### PR TITLE
{2023.06}[foss/2022b] waLBerla v6.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - GDAL-3.6.2-foss-2022b.eb
+  -  waLBerla-6.1-foss-2022b.eb


### PR DESCRIPTION
Sync NESSI with EESSI (PR 478)

SPDX license identifier: `GPL-3.0-only`

Missing packages:
```
2 out of 43 required modules missing:

* Boost.MPI/1.81.0-gompi-2022b (Boost.MPI-1.81.0-gompi-2022b.eb)
* waLBerla/6.1-foss-2022b (waLBerla-6.1-foss-2022b.eb)
```