### PR TITLE
{2023.06}[foss/2022b] R v4.2.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -1,3 +1,4 @@
 easyconfigs:
   - GDAL-3.6.2-foss-2022b.eb
-  -  waLBerla-6.1-foss-2022b.eb
+  - waLBerla-6.1-foss-2022b.eb
+  - R-4.2.2-foss-2022b.eb


### PR DESCRIPTION
Sync NESSI with EESSI (PR 452).

SPDX license identifier: `GPL-2.0-or-later`

Missing packages:
```
20 out of 140 required modules missing:

* libxslt/1.1.37-GCCcore-12.2.0 (libxslt-1.1.37-GCCcore-12.2.0.eb)
* nettle/3.8.1-GCCcore-12.2.0 (nettle-3.8.1-GCCcore-12.2.0.eb)
* Xvfb/21.1.6-GCCcore-12.2.0 (Xvfb-21.1.6-GCCcore-12.2.0.eb)
* Tk/8.6.12-GCCcore-12.2.0 (Tk-8.6.12-GCCcore-12.2.0.eb)
* NLopt/2.7.1-GCCcore-12.2.0 (NLopt-2.7.1-GCCcore-12.2.0.eb)
* libogg/1.3.5-GCCcore-12.2.0 (libogg-1.3.5-GCCcore-12.2.0.eb)
* FLAC/1.4.2-GCCcore-12.2.0 (FLAC-1.4.2-GCCcore-12.2.0.eb)
* libvorbis/1.3.7-GCCcore-12.2.0 (libvorbis-1.3.7-GCCcore-12.2.0.eb)
* UDUNITS/2.2.28-GCCcore-12.2.0 (UDUNITS-2.2.28-GCCcore-12.2.0.eb)
* libopus/1.3.1-GCCcore-12.2.0 (libopus-1.3.1-GCCcore-12.2.0.eb)
* GSL/2.7-GCC-12.2.0 (GSL-2.7-GCC-12.2.0.eb)
* LAME/3.100-GCCcore-12.2.0 (LAME-3.100-GCCcore-12.2.0.eb)
* libsndfile/1.2.0-GCCcore-12.2.0 (libsndfile-1.2.0-GCCcore-12.2.0.eb)
* GLPK/5.0-GCCcore-12.2.0 (GLPK-5.0-GCCcore-12.2.0.eb)
* MPFR/4.2.0-GCCcore-12.2.0 (MPFR-4.2.0-GCCcore-12.2.0.eb)
* libgit2/1.5.0-GCCcore-12.2.0 (libgit2-1.5.0-GCCcore-12.2.0.eb)
* jq/1.6-GCCcore-12.2.0 (jq-1.6-GCCcore-12.2.0.eb)
* Abseil/20230125.2-GCCcore-12.2.0 (Abseil-20230125.2-GCCcore-12.2.0.eb)
* protobuf/23.0-GCCcore-12.2.0 (protobuf-23.0-GCCcore-12.2.0.eb)
* R/4.2.2-foss-2022b (R-4.2.2-foss-2022b.eb)
```