### PR TITLE
{2023.06}[foss/2023b] DP3-6.0, WSClean 3.4 and deps

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
@@ -1,2 +1,10 @@
 easyconfigs:
   - CDO-2.2.2-gompi-2023b.eb
+  - AOFlagger-3.4.0-foss-2023b.eb
+  - arpack-ng-3.9.0-foss-2023b.eb
+  - Armadillo-12.8.0-foss-2023b.eb
+  - casacore-3.5.0-foss-2023b.eb
+  - IDG-1.2.0-foss-2023b.eb
+  - EveryBeam-0.5.2-foss-2023b.eb
+  - DP3-6.0-foss-2023b.eb
+  - WSClean-3.4-foss-2023b.eb

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -164,6 +164,32 @@ def post_prepare_hook(self, *args, **kwargs):
         POST_PREPARE_HOOKS[self.name](self, *args, **kwargs)
 
 
+def parse_hook_casacore_disable_vectorize(ec, eprefix):
+    """
+    Disable 'vectorize' toolchain option for casacore 3.5.0 on aarch64/neoverse_v1
+    Compiling casacore 3.5.0 with GCC 13.2.0 (foss-2023b) gives an error when building for aarch64/neoverse_v1.
+    See also, https://github.com/EESSI/software-layer/pull/479
+    """
+    if ec.name == 'casacore':
+        tcname, tcversion = ec['toolchain']['name'], ec['toolchain']['version']
+        if (
+            LooseVersion(ec.version) == LooseVersion('3.5.0') and
+            tcname == 'foss' and tcversion == '2023b'
+        ):
+            cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
+            if cpu_target == CPU_TARGET_NEOVERSE_V1:
+                if not hasattr(ec, 'toolchainopts'):
+                    ec['toolchainopts'] = {}
+                ec['toolchainopts']['vectorize'] = False
+                print_msg("Changed toochainopts for %s: %s", ec.name, ec['toolchainopts'])
+            else:
+                print_msg("Not changing option vectorize for %s on non-neoverse_v1", ec.name)
+        else:
+            print_msg("Not changing option vectorize for %s %s %s", ec.name, ec.version, ec.toolchain)
+    else:
+        raise EasyBuildError("casacore-specific hook triggered for non-casacore easyconfig?!")
+
+
 def parse_hook_cgal_toolchainopts_precise(ec, eprefix):
     """Enable 'precise' rather than 'strict' toolchain option for CGAL on POWER."""
     if ec.name == 'CGAL':
@@ -423,7 +449,7 @@ def pre_configure_hook_wrf_aarch64(self, *args, **kwargs):
             if LooseVersion(self.version) <= LooseVersion('3.9.0'):
                     self.cfg.update('preconfigopts', "sed -i 's/%s/%s/g' arch/configure_new.defaults && " % (pattern, repl))
                     print_msg("Using custom preconfigopts for %s: %s", self.name, self.cfg['preconfigopts'])
-                    
+
             if LooseVersion('4.0.0') <= LooseVersion(self.version) <= LooseVersion('4.2.1'):
                     self.cfg.update('preconfigopts', "sed -i 's/%s/%s/g' arch/configure.defaults && " % (pattern, repl))
                     print_msg("Using custom preconfigopts for %s: %s", self.name, self.cfg['preconfigopts'])
@@ -510,7 +536,7 @@ def pre_test_hook_ignore_failing_tests_netCDF(self, *args, **kwargs):
     """
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
     if self.name == 'netCDF' and self.version == '4.9.2' and cpu_target == CPU_TARGET_NEOVERSE_V1:
-        self.cfg['testopts'] = "|| echo ignoring failing tests" 
+        self.cfg['testopts'] = "|| echo ignoring failing tests"
 
 def pre_test_hook_increase_max_failed_tests_arm_PyTorch(self, *args, **kwargs):
     """
@@ -675,6 +701,7 @@ def inject_gpu_property(ec):
 
 
 PARSE_HOOKS = {
+    'casacore': parse_hook_casacore_disable_vectorize,
     'CGAL': parse_hook_cgal_toolchainopts_precise,
     'fontconfig': parse_hook_fontconfig_add_fonts,
     'GPAW': parse_hook_gpaw_harcoded_path,

--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -193,6 +193,7 @@ while [[ $# -gt 0 ]]; do
     -x|--http-proxy)
       HTTP_PROXY="$2"
       export http_proxy=${HTTP_PROXY}
+      export ftp_proxy=${HTTP_PROXY}
       shift 2
       ;;
     -y|--https-proxy)

--- a/run_in_compat_layer_env.sh
+++ b/run_in_compat_layer_env.sh
@@ -32,6 +32,9 @@ fi
 if [ ! -z ${https_proxy} ]; then
     INPUT="export https_proxy=${https_proxy}; ${INPUT}"
 fi
+if [ ! -z ${ftp_proxy} ]; then
+    INPUT="export ftp_proxy=${ftp_proxy}; ${INPUT}"
+fi
 
 echo "Running '${INPUT}' in EESSI (${EESSI_CVMFS_REPO}) ${EESSI_VERSION} compatibility layer environment..."
 ${EESSI_COMPAT_LAYER_DIR}/startprefix <<< "${INPUT}"


### PR DESCRIPTION
Sync NESSI with EESSI (PR 479).

SPDX license identifiers:
- `AOFlagger-3.4.0-foss-2023b.eb`:
- `arpack-ng-3.9.0-foss-2023b.eb`:
- `Armadillo-12.8.0-foss-2023b.eb`:
- `casacore-3.5.0-foss-2023b.eb`:
- `IDG-1.2.0-foss-2023b.eb`:
- `EveryBeam-0.5.2-foss-2023b.eb`:
- `DP3-6.0-foss-2023b.eb`:
- `WSClean-3.4-foss-2023b.eb`:

Missing packages:

- `AOFlagger-3.4.0-foss-2023b.eb`
```
13 out of 82 required modules missing:

* CFITSIO/4.3.1-GCCcore-13.2.0 (CFITSIO-4.3.1-GCCcore-13.2.0.eb)
* GSL/2.7-GCC-13.2.0 (GSL-2.7-GCC-13.2.0.eb)
* Lua/5.4.6-GCCcore-13.2.0 (Lua-5.4.6-GCCcore-13.2.0.eb)
* PCRE/8.45-GCCcore-13.2.0 (PCRE-8.45-GCCcore-13.2.0.eb)
* libidn2/2.3.2-GCCcore-13.2.0 (libidn2-2.3.2-GCCcore-13.2.0.eb)
* wget/1.21.4-GCCcore-13.2.0 (wget-1.21.4-GCCcore-13.2.0.eb)
* ICU/74.1-GCCcore-13.2.0 (ICU-74.1-GCCcore-13.2.0.eb)
* Boost/1.83.0-GCC-13.2.0 (Boost-1.83.0-GCC-13.2.0.eb)
* Boost.Python/1.83.0-GCC-13.2.0 (Boost.Python-1.83.0-GCC-13.2.0.eb)
* PGPLOT/5.2.2-GCCcore-13.2.0 (PGPLOT-5.2.2-GCCcore-13.2.0.eb)
* WCSLIB/7.11-GCC-13.2.0 (WCSLIB-7.11-GCC-13.2.0.eb)
* casacore/3.5.0-foss-2023b (casacore-3.5.0-foss-2023b.eb)
* AOFlagger/3.4.0-foss-2023b (AOFlagger-3.4.0-foss-2023b.eb)
```

- `arpack-ng-3.9.0-foss-2023b.eb`
```
1 out of 36 required modules missing:

* arpack-ng/3.9.0-foss-2023b (arpack-ng-3.9.0-foss-2023b.eb)
```

- `Armadillo-12.8.0-foss-2023b.eb`
```
4 out of 42 required modules missing:

* ICU/74.1-GCCcore-13.2.0 (ICU-74.1-GCCcore-13.2.0.eb)
* Boost/1.83.0-GCC-13.2.0 (Boost-1.83.0-GCC-13.2.0.eb)
* arpack-ng/3.9.0-foss-2023b (arpack-ng-3.9.0-foss-2023b.eb)
* Armadillo/12.8.0-foss-2023b (Armadillo-12.8.0-foss-2023b.eb)
```

- `casacore-3.5.0-foss-2023b.eb`
```
11 out of 80 required modules missing:

* CFITSIO/4.3.1-GCCcore-13.2.0 (CFITSIO-4.3.1-GCCcore-13.2.0.eb)
* PCRE/8.45-GCCcore-13.2.0 (PCRE-8.45-GCCcore-13.2.0.eb)
* libidn2/2.3.2-GCCcore-13.2.0 (libidn2-2.3.2-GCCcore-13.2.0.eb)
* wget/1.21.4-GCCcore-13.2.0 (wget-1.21.4-GCCcore-13.2.0.eb)
* GSL/2.7-GCC-13.2.0 (GSL-2.7-GCC-13.2.0.eb)
* ICU/74.1-GCCcore-13.2.0 (ICU-74.1-GCCcore-13.2.0.eb)
* Boost/1.83.0-GCC-13.2.0 (Boost-1.83.0-GCC-13.2.0.eb)
* Boost.Python/1.83.0-GCC-13.2.0 (Boost.Python-1.83.0-GCC-13.2.0.eb)
* PGPLOT/5.2.2-GCCcore-13.2.0 (PGPLOT-5.2.2-GCCcore-13.2.0.eb)
* WCSLIB/7.11-GCC-13.2.0 (WCSLIB-7.11-GCC-13.2.0.eb)
* casacore/3.5.0-foss-2023b (casacore-3.5.0-foss-2023b.eb)
```

- `IDG-1.2.0-foss-2023b.eb`
```
3 out of 40 required modules missing:

* ICU/74.1-GCCcore-13.2.0 (ICU-74.1-GCCcore-13.2.0.eb)
* Boost/1.83.0-GCC-13.2.0 (Boost-1.83.0-GCC-13.2.0.eb)
* IDG/1.2.0-foss-2023b (IDG-1.2.0-foss-2023b.eb)
```

- `EveryBeam-0.5.2-foss-2023b.eb`
```
12 out of 81 required modules missing:

* CFITSIO/4.3.1-GCCcore-13.2.0 (CFITSIO-4.3.1-GCCcore-13.2.0.eb)
* PCRE/8.45-GCCcore-13.2.0 (PCRE-8.45-GCCcore-13.2.0.eb)
* libidn2/2.3.2-GCCcore-13.2.0 (libidn2-2.3.2-GCCcore-13.2.0.eb)
* wget/1.21.4-GCCcore-13.2.0 (wget-1.21.4-GCCcore-13.2.0.eb)
* GSL/2.7-GCC-13.2.0 (GSL-2.7-GCC-13.2.0.eb)
* ICU/74.1-GCCcore-13.2.0 (ICU-74.1-GCCcore-13.2.0.eb)
* Boost/1.83.0-GCC-13.2.0 (Boost-1.83.0-GCC-13.2.0.eb)
* Boost.Python/1.83.0-GCC-13.2.0 (Boost.Python-1.83.0-GCC-13.2.0.eb)
* PGPLOT/5.2.2-GCCcore-13.2.0 (PGPLOT-5.2.2-GCCcore-13.2.0.eb)
* WCSLIB/7.11-GCC-13.2.0 (WCSLIB-7.11-GCC-13.2.0.eb)
* casacore/3.5.0-foss-2023b (casacore-3.5.0-foss-2023b.eb)
* EveryBeam/0.5.2-foss-2023b (EveryBeam-0.5.2-foss-2023b.eb)
```

- `DP3-6.0-foss-2023b.eb`
```
18 out of 87 required modules missing:

* CFITSIO/4.3.1-GCCcore-13.2.0 (CFITSIO-4.3.1-GCCcore-13.2.0.eb)
* GSL/2.7-GCC-13.2.0 (GSL-2.7-GCC-13.2.0.eb)
* PCRE/8.45-GCCcore-13.2.0 (PCRE-8.45-GCCcore-13.2.0.eb)
* libidn2/2.3.2-GCCcore-13.2.0 (libidn2-2.3.2-GCCcore-13.2.0.eb)
* wget/1.21.4-GCCcore-13.2.0 (wget-1.21.4-GCCcore-13.2.0.eb)
* ICU/74.1-GCCcore-13.2.0 (ICU-74.1-GCCcore-13.2.0.eb)
* Boost/1.83.0-GCC-13.2.0 (Boost-1.83.0-GCC-13.2.0.eb)
* Boost.Python/1.83.0-GCC-13.2.0 (Boost.Python-1.83.0-GCC-13.2.0.eb)
* Lua/5.4.6-GCCcore-13.2.0 (Lua-5.4.6-GCCcore-13.2.0.eb)
* PGPLOT/5.2.2-GCCcore-13.2.0 (PGPLOT-5.2.2-GCCcore-13.2.0.eb)
* WCSLIB/7.11-GCC-13.2.0 (WCSLIB-7.11-GCC-13.2.0.eb)
* arpack-ng/3.9.0-foss-2023b (arpack-ng-3.9.0-foss-2023b.eb)
* IDG/1.2.0-foss-2023b (IDG-1.2.0-foss-2023b.eb)
* Armadillo/12.8.0-foss-2023b (Armadillo-12.8.0-foss-2023b.eb)
* casacore/3.5.0-foss-2023b (casacore-3.5.0-foss-2023b.eb)
* EveryBeam/0.5.2-foss-2023b (EveryBeam-0.5.2-foss-2023b.eb)
* AOFlagger/3.4.0-foss-2023b (AOFlagger-3.4.0-foss-2023b.eb)
* DP3/6.0-foss-2023b (DP3-6.0-foss-2023b.eb)
```

- `WSClean-3.4-foss-2023b.eb`:
```
14 out of 83 required modules missing:

* CFITSIO/4.3.1-GCCcore-13.2.0 (CFITSIO-4.3.1-GCCcore-13.2.0.eb)
* PCRE/8.45-GCCcore-13.2.0 (PCRE-8.45-GCCcore-13.2.0.eb)
* GSL/2.7-GCC-13.2.0 (GSL-2.7-GCC-13.2.0.eb)
* libidn2/2.3.2-GCCcore-13.2.0 (libidn2-2.3.2-GCCcore-13.2.0.eb)
* wget/1.21.4-GCCcore-13.2.0 (wget-1.21.4-GCCcore-13.2.0.eb)
* ICU/74.1-GCCcore-13.2.0 (ICU-74.1-GCCcore-13.2.0.eb)
* Boost/1.83.0-GCC-13.2.0 (Boost-1.83.0-GCC-13.2.0.eb)
* Boost.Python/1.83.0-GCC-13.2.0 (Boost.Python-1.83.0-GCC-13.2.0.eb)
* PGPLOT/5.2.2-GCCcore-13.2.0 (PGPLOT-5.2.2-GCCcore-13.2.0.eb)
* WCSLIB/7.11-GCC-13.2.0 (WCSLIB-7.11-GCC-13.2.0.eb)
* IDG/1.2.0-foss-2023b (IDG-1.2.0-foss-2023b.eb)
* casacore/3.5.0-foss-2023b (casacore-3.5.0-foss-2023b.eb)
* EveryBeam/0.5.2-foss-2023b (EveryBeam-0.5.2-foss-2023b.eb)
* WSClean/3.4-foss-2023b (WSClean-3.4-foss-2023b.eb)
```

- all missing packages
```
* AOFlagger/3.4.0-foss-2023b (AOFlagger-3.4.0-foss-2023b.eb)
* Armadillo/12.8.0-foss-2023b (Armadillo-12.8.0-foss-2023b.eb)
* arpack-ng/3.9.0-foss-2023b (arpack-ng-3.9.0-foss-2023b.eb)
* Boost/1.83.0-GCC-13.2.0 (Boost-1.83.0-GCC-13.2.0.eb)
* Boost.Python/1.83.0-GCC-13.2.0 (Boost.Python-1.83.0-GCC-13.2.0.eb)
* casacore/3.5.0-foss-2023b (casacore-3.5.0-foss-2023b.eb)
* CFITSIO/4.3.1-GCCcore-13.2.0 (CFITSIO-4.3.1-GCCcore-13.2.0.eb)
* DP3/6.0-foss-2023b (DP3-6.0-foss-2023b.eb)
* EveryBeam/0.5.2-foss-2023b (EveryBeam-0.5.2-foss-2023b.eb)
* GSL/2.7-GCC-13.2.0 (GSL-2.7-GCC-13.2.0.eb)
* ICU/74.1-GCCcore-13.2.0 (ICU-74.1-GCCcore-13.2.0.eb)
* IDG/1.2.0-foss-2023b (IDG-1.2.0-foss-2023b.eb)
* libidn2/2.3.2-GCCcore-13.2.0 (libidn2-2.3.2-GCCcore-13.2.0.eb)
* Lua/5.4.6-GCCcore-13.2.0 (Lua-5.4.6-GCCcore-13.2.0.eb)
* PCRE/8.45-GCCcore-13.2.0 (PCRE-8.45-GCCcore-13.2.0.eb)
* PGPLOT/5.2.2-GCCcore-13.2.0 (PGPLOT-5.2.2-GCCcore-13.2.0.eb)
* WCSLIB/7.11-GCC-13.2.0 (WCSLIB-7.11-GCC-13.2.0.eb)
* wget/1.21.4-GCCcore-13.2.0 (wget-1.21.4-GCCcore-13.2.0.eb)
* WSClean/3.4-foss-2023b (WSClean-3.4-foss-2023b.eb)
```