### PR TITLE
{2023.06}[foss/2022b] WRF v4.4.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -2,3 +2,4 @@ easyconfigs:
   - GDAL-3.6.2-foss-2022b.eb
   - waLBerla-6.1-foss-2022b.eb
   - R-4.2.2-foss-2022b.eb
+  - WRF-4.4.1-foss-2022b-dmpar.eb


### PR DESCRIPTION
Sync NESSI with EESSI (PR 480)

SPDX license identifier: https://github.com/wrf-model/WRF/tree/master?tab=License-1-ov-file

Missing packages:
```
4 out of 51 required modules missing:

* tcsh/6.24.07-GCCcore-12.2.0 (tcsh-6.24.07-GCCcore-12.2.0.eb)
* time/1.9-GCCcore-12.2.0 (time-1.9-GCCcore-12.2.0.eb)
* netCDF-Fortran/4.6.0-gompi-2022b (netCDF-Fortran-4.6.0-gompi-2022b.eb)
* WRF/4.4.1-foss-2022b-dmpar (WRF-4.4.1-foss-2022b-dmpar.eb)
```
