### PR TITLE
{2023.06}[foss/2023a] OpenFOAM v10

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -9,3 +9,4 @@ easyconfigs:
         include-easyblocks-from-pr: 3036
   - JupyterNotebook-7.0.2-GCCcore-12.3.0.eb
   - R-bundle-CRAN-2023.12-foss-2023a.eb
+  - OpenFOAM-10-foss-2023a.eb


### PR DESCRIPTION
Sync NESSI with EESSI (PR 404).

SPDX license identifier: `GPL-3.0-or-later`

Missing packages:
```
1 out of 113 required modules missing:

* OpenFOAM/10-foss-2023a (OpenFOAM-10-foss-2023a.eb)
```
