### PR TITLE
{2023.06}[foss/2023b] Qt5 v5.15.13

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - CDO-2.2.2-gompi-2023b.eb
+  - Qt5-5.15.13-GCCcore-13.2.0.eb


### PR DESCRIPTION
Sync NESSI with EESSI (PR 462).

SPDX license identifier: `LGPL-3.0-or-later`

Missing packages:
```
9 out of 57 required modules missing:

* re2c/3.1-GCCcore-13.2.0 (re2c-3.1-GCCcore-13.2.0.eb)
* double-conversion/3.3.0-GCCcore-13.2.0 (double-conversion-3.3.0-GCCcore-13.2.0.eb)
* graphite2/1.3.14-GCCcore-13.2.0 (graphite2-1.3.14-GCCcore-13.2.0.eb)
* snappy/1.1.10-GCCcore-13.2.0 (snappy-1.1.10-GCCcore-13.2.0.eb)
* NSPR/4.35-GCCcore-13.2.0 (NSPR-4.35-GCCcore-13.2.0.eb)
* NSS/3.94-GCCcore-13.2.0 (NSS-3.94-GCCcore-13.2.0.eb)
* nodejs/20.9.0-GCCcore-13.2.0 (nodejs-20.9.0-GCCcore-13.2.0.eb)
* libGLU/9.0.3-GCCcore-13.2.0 (libGLU-9.0.3-GCCcore-13.2.0.eb)
* Qt5/5.15.13-GCCcore-13.2.0 (Qt5-5.15.13-GCCcore-13.2.0.eb)
```