### PR TITLE
{2023.06}[foss/2023a] PyOpenGL v3.1.7

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -10,3 +10,4 @@ easyconfigs:
   - JupyterNotebook-7.0.2-GCCcore-12.3.0.eb
   - R-bundle-CRAN-2023.12-foss-2023a.eb
   - OpenFOAM-10-foss-2023a.eb
+  - PyOpenGL-3.1.7-GCCcore-12.3.0.eb


### PR DESCRIPTION
Sync NESSI with EESSI (PR 503).

SPDX license identifier: `OpenGL-ctypes License`

Missing packages:
```
1 out of 36 required modules missing:

* PyOpenGL/3.1.7-GCCcore-12.3.0 (PyOpenGL-3.1.7-GCCcore-12.3.0.eb)
```