### PR TITLE
{2023.06}[foss/2023a] ipympl v0.9.3

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -11,3 +11,4 @@ easyconfigs:
   - R-bundle-CRAN-2023.12-foss-2023a.eb
   - OpenFOAM-10-foss-2023a.eb
   - PyOpenGL-3.1.7-GCCcore-12.3.0.eb
+  - ipympl-0.9.3-foss-2023a.eb


### PR DESCRIPTION
Sync NESSI with EESSI (PR 505)

SPDX license identifier: `BSD-3-Clause`

Missing packages:
```
1 out of 97 required modules missing:

* ipympl/0.9.3-foss-2023a (ipympl-0.9.3-foss-2023a.eb)
```