### PR TITLE
{2023.06}[foss/2023b] Wayland v1.22.0

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - CDO-2.2.2-gompi-2023b.eb
+  - Wayland-1.22.0-GCCcore-13.2.0.eb


### PR DESCRIPTION
Sync NESSI with EESSI (PR 520).

SPDX license identifier: `MIT`

Missing packages:
```
1 out of 17 required modules missing:

* Wayland/1.22.0-GCCcore-13.2.0 (Wayland-1.22.0-GCCcore-13.2.0.eb)
```