### PR TITLE
{2023.06}[foss/2023b] HarfBuzz v8.2.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
@@ -1,3 +1,4 @@
 easyconfigs:
   - CDO-2.2.2-gompi-2023b.eb
   - Wayland-1.22.0-GCCcore-13.2.0.eb
+  - HarfBuzz-8.2.2-GCCcore-13.2.0.eb


### PR DESCRIPTION
Sync NESSI with EESSI (PR 462).

- some of the missing packages for #332 

SPDX license identifier: old `MIT` license

Missing packages:
```
7 out of 33 required modules missing:

* PCRE2/10.42-GCCcore-13.2.0 (PCRE2-10.42-GCCcore-13.2.0.eb)
* pixman/0.42.2-GCCcore-13.2.0 (pixman-0.42.2-GCCcore-13.2.0.eb)
* ICU/74.1-GCCcore-13.2.0 (ICU-74.1-GCCcore-13.2.0.eb)
* GLib/2.78.1-GCCcore-13.2.0 (GLib-2.78.1-GCCcore-13.2.0.eb)
* cairo/1.18.0-GCCcore-13.2.0 (cairo-1.18.0-GCCcore-13.2.0.eb)
* GObject-Introspection/1.78.1-GCCcore-13.2.0 (GObject-Introspection-1.78.1-GCCcore-13.2.0.eb)
* HarfBuzz/8.2.2-GCCcore-13.2.0 (HarfBuzz-8.2.2-GCCcore-13.2.0.eb)
```