### PR TITLE
{2023.06}[foss/2023b] Mesa v23.1.9

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
@@ -1,3 +1,4 @@
 easyconfigs:
   - CDO-2.2.2-gompi-2023b.eb
   - Wayland-1.22.0-GCCcore-13.2.0.eb
+  - Mesa-23.1.9-GCCcore-13.2.0.eb


### PR DESCRIPTION
Sync NESSI with EESSI (PR 462).

- some of the missing packages for #332 

SPDX license identifier: `MIT`

Missing packages:
```
6 out of 36 required modules missing:

* Mako/1.2.4-GCCcore-13.2.0 (Mako-1.2.4-GCCcore-13.2.0.eb)
* libunwind/1.6.2-GCCcore-13.2.0 (libunwind-1.6.2-GCCcore-13.2.0.eb)
* LLVM/16.0.6-GCCcore-13.2.0 (LLVM-16.0.6-GCCcore-13.2.0.eb)
* libdrm/2.4.117-GCCcore-13.2.0 (libdrm-2.4.117-GCCcore-13.2.0.eb)
* libglvnd/1.7.0-GCCcore-13.2.0 (libglvnd-1.7.0-GCCcore-13.2.0.eb)
* Mesa/23.1.9-GCCcore-13.2.0 (Mesa-23.1.9-GCCcore-13.2.0.eb)
```