### PR TITLE
{2023.06}[foss/2023a] SuperLU_DIST v8.1.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -12,3 +12,6 @@ easyconfigs:
   - OpenFOAM-10-foss-2023a.eb
   - PyOpenGL-3.1.7-GCCcore-12.3.0.eb
   - ipympl-0.9.3-foss-2023a.eb
+  - SuperLU_DIST-8.1.2-foss-2023a.eb:
+      options:
+        from-pr: 20162


### PR DESCRIPTION
Sync NESSI with EESSI (part of PR 522).

SPDX license identifier: _slightly modified BSD-style license_

Missing packages:
```
2 out of 36 required modules missing:

* ParMETIS/4.0.3-gompi-2023a (ParMETIS-4.0.3-gompi-2023a.eb)
* SuperLU_DIST/8.1.2-foss-2023a (SuperLU_DIST-8.1.2-foss-2023a.eb)
```