### PR TITLE
{2023.06}[foss/2023b] Qt5 dependencies

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
@@ -3,3 +3,11 @@ easyconfigs:
   - Wayland-1.22.0-GCCcore-13.2.0.eb
   - HarfBuzz-8.2.2-GCCcore-13.2.0.eb
   - Mesa-23.1.9-GCCcore-13.2.0.eb
+  - re2c-3.1-GCCcore-13.2.0.eb
+  - double-conversion-3.3.0-GCCcore-13.2.0.eb
+  - graphite2-1.3.14-GCCcore-13.2.0.eb
+  - snappy-1.1.10-GCCcore-13.2.0.eb
+  - NSPR-4.35-GCCcore-13.2.0.eb
+  - NSS-3.94-GCCcore-13.2.0.eb
+  - nodejs-20.9.0-GCCcore-13.2.0.eb
+  - libGLU-9.0.3-GCCcore-13.2.0.eb


### PR DESCRIPTION
Sync NESSI with EESSI (all missing dependencies for #332)

SPDX license identifiers: just dependencies

Missing packages:
```
1 out of 10 required modules missing:

* re2c/3.1-GCCcore-13.2.0 (re2c-3.1-GCCcore-13.2.0.eb)

1 out of 7 required modules missing:

* double-conversion/3.3.0-GCCcore-13.2.0 (double-conversion-3.3.0-GCCcore-13.2.0.eb)

1 out of 7 required modules missing:

* graphite2/1.3.14-GCCcore-13.2.0 (graphite2-1.3.14-GCCcore-13.2.0.eb)

1 out of 7 required modules missing:

* snappy/1.1.10-GCCcore-13.2.0 (snappy-1.1.10-GCCcore-13.2.0.eb)

2 out of 4 required modules missing:

* NSPR/4.35-GCCcore-13.2.0 (NSPR-4.35-GCCcore-13.2.0.eb)
* NSS/3.94-GCCcore-13.2.0 (NSS-3.94-GCCcore-13.2.0.eb)

1 out of 11 required modules missing:

* nodejs/20.9.0-GCCcore-13.2.0 (nodejs-20.9.0-GCCcore-13.2.0.eb)

1 out of 37 required modules missing:

* libGLU/9.0.3-GCCcore-13.2.0 (libGLU-9.0.3-GCCcore-13.2.0.eb)
```