### PR TITLE
{2023.06}[foss/2023a] Hypre/2.29.0, SuiteSparse/7.1.0 and netCDF-Fortran/4.6.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -15,3 +15,6 @@ easyconfigs:
   - SuperLU_DIST-8.1.2-foss-2023a.eb:
       options:
         from-pr: 20162
+  - SuiteSparse-7.1.0-foss-2023a.eb
+  - Hypre-2.29.0-foss-2023a.eb
+  - netCDF-Fortran-4.6.1-gompi-2023a.eb


### PR DESCRIPTION
Sync NESSI with EESSI (part of 522).

SPDX license identifier(s):
- Hypre: `Apache-2.0`
- SuiteSparse: `BSD-3-Clause`
- netCDF-Fortran: _netCDF_

Missing packages:
```
1 out of 37 required modules missing:

* SuiteSparse/7.1.0-foss-2023a (SuiteSparse-7.1.0-foss-2023a.eb)

1 out of 35 required modules missing:

* Hypre/2.29.0-foss-2023a (Hypre-2.29.0-foss-2023a.eb)

1 out of 36 required modules missing:

* netCDF-Fortran/4.6.1-gompi-2023a (netCDF-Fortran-4.6.1-gompi-2023a.eb)
```