### PR TITLE
Rebuild `hatchling 1.18.0`, `Python 3.11.*`, `Python-bundle-PyPI-2023.*` to solve `setuptools_scm`

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/rebuilds/20240501-eb-4.9.1-move-setuptools_scm-from-hatchling-to-Python.yml
+++ b/easystacks/pilot.nessi.no/2023.06/rebuilds/20240501-eb-4.9.1-move-setuptools_scm-from-hatchling-to-Python.yml
@@ -1,0 +1,13 @@
+# 2024-05-01
+# Move setuptools_scm extension from hatchling to Python by rebuilding
+# all affected modules with EasyBuild 4.9.1.
+# This solves an issue with pyarrow, which is part of the Arrow installation.
+# https://github.com/easybuilders/easybuild-easyconfigs/pull/19777
+# https://github.com/easybuilders/easybuild-easyconfigs/issues/19849
+easyconfigs:
+  - hatchling-1.18.0-GCCcore-12.3.0.eb
+  - hatchling-1.18.0-GCCcore-13.2.0.eb
+  - Python-bundle-PyPI-2023.06-GCCcore-12.3.0.eb
+  - Python-bundle-PyPI-2023.10-GCCcore-13.2.0.eb
+  - Python-3.11.3-GCCcore-12.3.0.eb
+  - Python-3.11.5-GCCcore-13.2.0.eb


### PR DESCRIPTION
Sync NESSI with EESSI (PR 546).

We first need to remove the packages on the Stratum-0. Then after a while trigger the building, then ingest ...