### PR TITLE
{2023.06}[foss/2023a] R-bundle-bioconductor v3.18

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -232,8 +232,6 @@ else
         # load EasyBuild module (will be installed if it's not available yet)
         source ${TOPDIR}/load_easybuild_module.sh ${eb_version}
 
-        # export EASYBUILD_PARALLEL=4
-
         ${EB} --show-config
 
         echo_green "All set, let's start installing some software with EasyBuild v${eb_version} in ${EASYBUILD_INSTALLPATH}..."

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -232,6 +232,8 @@ else
         # load EasyBuild module (will be installed if it's not available yet)
         source ${TOPDIR}/load_easybuild_module.sh ${eb_version}
 
+        export EASYBUILD_PARALLEL=4
+
         ${EB} --show-config
 
         echo_green "All set, let's start installing some software with EasyBuild v${eb_version} in ${EASYBUILD_INSTALLPATH}..."

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -232,7 +232,7 @@ else
         # load EasyBuild module (will be installed if it's not available yet)
         source ${TOPDIR}/load_easybuild_module.sh ${eb_version}
 
-        export EASYBUILD_PARALLEL=4
+        # export EASYBUILD_PARALLEL=4
 
         ${EB} --show-config
 

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -18,3 +18,7 @@ easyconfigs:
   - SuiteSparse-7.1.0-foss-2023a.eb
   - Hypre-2.29.0-foss-2023a.eb
   - netCDF-Fortran-4.6.1-gompi-2023a.eb
+  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20379
+        from-commit: 968654eef0a4984fc82e475ae4739eb42d8a2275

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -22,4 +22,6 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20379
         # Note, it's not the merge commit but the one before.
-        from-commit: ae2fc38307b56ae7ac12dff95c9d07404e1a8530
+        # from-commit: ae2fc38307b56ae7ac12dff95c9d07404e1a8530
+        # trying from-pr as an alternative
+        from-pr: 20379

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -21,4 +21,5 @@ easyconfigs:
   - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20379
-        from-commit: 968654eef0a4984fc82e475ae4739eb42d8a2275
+        # Note, it's not the merge commit but the one before.
+        from-commit: ae2fc38307b56ae7ac12dff95c9d07404e1a8530


### PR DESCRIPTION
Sync NESSI with EESSI (PR 533).

SPDX license identifiers: _too many to determine manually_

Missing packages:
```
5 out of 156 required modules missing:

* RapidJSON/1.1.0-20230928-GCCcore-12.3.0 (RapidJSON-1.1.0-20230928-GCCcore-12.3.0.eb)
* utf8proc/2.8.0-GCCcore-12.3.0 (utf8proc-2.8.0-GCCcore-12.3.0.eb)
* Arrow/14.0.1-gfbf-2023a (Arrow-14.0.1-gfbf-2023a.eb)
* arrow-R/14.0.1-foss-2023a-R-4.3.2 (arrow-R-14.0.1-foss-2023a-R-4.3.2.eb)
* R-bundle-Bioconductor/3.18-foss-2023a-R-4.3.2 (R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb)
```
