### PR TITLE
{2023.06}[GCC/12.3.0] ncdu V1.18

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -18,3 +18,4 @@ easyconfigs:
   - SuiteSparse-7.1.0-foss-2023a.eb
   - Hypre-2.29.0-foss-2023a.eb
   - netCDF-Fortran-4.6.1-gompi-2023a.eb
+  - ncdu-1.18-GCC-12.3.0.eb


### PR DESCRIPTION
Adding ncdu 1.18
lic: `MIT`
Sync with EESSI(PR 542)

Missing packages:
```
1 out of 3 required modules missing:

* ncdu/1.18-GCC-12.3.0 (ncdu-1.18-GCC-12.3.0.eb)
```
