### PR TITLE
Remove `build_container.sh` script (replaced by more capable `eessi_container.sh`)

### DIFF
--- a/.github/workflows/tests_scripts.yml
+++ b/.github/workflows/tests_scripts.yml
@@ -3,9 +3,9 @@ name: Tests for scripts
 on:
   push:
     paths:
-      - build_container.sh
       - create_directory_tarballs.sh
       - create_lmodsitepackage.py
+      - eessi_container.sh
       - EESSI-install-software.sh
       - install_software_layer.sh
       - load_easybuild_module.sh
@@ -15,9 +15,9 @@ on:
 
   pull_request:
     paths:
-      - build_container.sh
       - create_directory_tarballs.sh
       - create_lmodsitepackage.py
+      - eessi_container.sh
       - EESSI-install-software.sh
       - install_software_layer.sh
       - load_easybuild_module.sh


### PR DESCRIPTION
Sync with EESSI(PR 544)

In NESSI only `.github/workflows/tests_scripts.yml` was modified as `build_container.sh` was already removed.