### PR TITLE
{2023.06}[system] CUDA v12.1.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/README.md
+++ b/easystacks/pilot.nessi.no/2023.06/README.md
@@ -4,4 +4,4 @@ Software installed with system toolchain should be installed first,
 this includes EasyBuild itself, see `eessi-2023.06-eb-4.8.2-001-system.yml` .
 
 CUDA installations must be done before CUDA is required as dependency for something
-built with a non-system toolchain, see `eessi-2023.06-eb-4.8.2-010-CUDA.yml` .
+built with a non-system toolchain, see `eessi-2023.06-eb-4.9.1-010-CUDA.yml` .

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-010-CUDA.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-010-CUDA.yml
@@ -1,0 +1,6 @@
+easyconfigs:
+  - CUDA-12.1.1.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3045
+        # include-easyblocks-from-pr: 3045
+        accept-eula-for: CUDA


### PR DESCRIPTION
Adding CUDA to NESSI. Follows EESSI PR https://github.com/EESSI/software-layer/pull/434

License: NVIDIA

Missing packages:
```
1 out of 1 required modules missing:

* CUDA/12.1.1 (CUDA-12.1.1.eb)
```