### PR TITLE
{2023.06}[foss/2023b] GDB v13.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
@@ -22,3 +22,4 @@ easyconfigs:
   - GROMACS-2024.1-foss-2023b.eb:
       options:
         from-pr: 20439
+  - GDB-13.2-GCCcore-13.2.0.eb


### PR DESCRIPTION
Add packages locally found on Sigma2 clusters to NESSI.

SPDX license identifier: `GPL-3.0`

Missing packages:
```
5 out of 15 required modules missing:

* GMP/6.3.0-GCCcore-13.2.0 (GMP-6.3.0-GCCcore-13.2.0.eb)
* ISL/0.26-GCCcore-13.2.0 (ISL-0.26-GCCcore-13.2.0.eb)
* MPFR/4.2.1-GCCcore-13.2.0 (MPFR-4.2.1-GCCcore-13.2.0.eb)
* MPC/1.3.1-GCCcore-13.2.0 (MPC-1.3.1-GCCcore-13.2.0.eb)
* GDB/13.2-GCCcore-13.2.0 (GDB-13.2-GCCcore-13.2.0.eb)
```