### PR TITLE
{2023.06}[foss/2023a] CUDA samples v12.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -26,3 +26,11 @@ easyconfigs:
         # from-commit: ae2fc38307b56ae7ac12dff95c9d07404e1a8530
         # trying from-pr as an alternative
         from-pr: 20379
+  - CUDA-Samples-12.1-GCC-12.3.0-CUDA-12.1.1.eb:
+      # use easyconfig that only install subset of CUDA samples,
+      # to circumvent problem with nvcc linking to glibc of host OS,
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19189;
+      # and where additional samples are excluded because they fail to build on aarch64,
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19451;
+      options:
+        from-pr: 19451


### PR DESCRIPTION
Adding CUDA samples to NESSI. Follows EESSI PR https://github.com/EESSI/software-layer/pull/434

License: NVIDIA

Missing packages:
```
1 out of 4 required modules missing:

* CUDA-Samples/12.1-GCC-12.3.0-CUDA-12.1.1 (CUDA-Samples-12.1-GCC-12.3.0-CUDA-12.1.1.eb)
```