### PR TITLE
add possibility to ignore certain hooks

### DIFF
--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -20,6 +20,27 @@ local function read_file(path)
     return content
 end
 
+local function from_eessi_prefix(t)
+    -- eessi_prefix is the prefix with official EESSI modules
+    -- e.g. /cvmfs/software.eessi.io/versions/2023.06
+    local eessi_prefix = os.getenv("EESSI_PREFIX")
+
+    -- If EESSI_PREFIX wasn't defined, we cannot check if this module was from the EESSI environment
+    -- In that case, we assume it isn't, otherwise EESSI_PREFIX would (probably) have been set
+    if eessi_prefix == nil then
+        return False
+    else
+        -- NOTE: exact paths for site so may need to be updated later.
+        -- See https://github.com/EESSI/software-layer/pull/371
+        -- eessi_prefix_host_injections is the prefix with site-extensions (i.e. additional modules)
+        -- to the official EESSI modules, e.g. /cvmfs/software.eessi.io/host_injections/2023.06
+        local eessi_prefix_host_injections = string.gsub(eessi_prefix, 'versions', 'host_injections')
+
+       -- Check if the full modulepath starts with the eessi_prefix_*
+        return string.find(t.fn, "^" .. eessi_prefix) ~= nil or string.find(t.fn, "^" .. eessi_prefix_host_injections) ~= nil
+    end
+end
+
 local function load_site_specific_hooks()
     -- This function will be run after the EESSI hooks are registered
     -- It will load a local SitePackage.lua that is architecture independent (if it exists) from e.g.
@@ -153,9 +174,12 @@ end
 -- Combine both functions into a single one, as we can only register one function as load hook in lmod
 -- Also: make it non-local, so it can be imported and extended by other lmodrc files if needed
 function eessi_load_hook(t)
-    eessi_cuda_enabled_load_hook(t)
+    -- Only apply CUDA hooks if the loaded module is in the EESSI prefix
+    -- This avoids getting an Lmod Error when trying to load a CUDA module from a local software stack
+    if from_eessi_prefix(t) then
+        eessi_cuda_enabled_load_hook(t)
+    end
 end
-
 
 hook.register("load", eessi_load_hook)
 


### PR DESCRIPTION
This should ensure that we are not always checking if a local module for, eg, CUDA exists. For example, this is needed to build modules that depend on CUDA.

The PR follows the EESSI PR 530 which is not merged yet. Hence we may have to do further changes in case PR530 is changed.

- https://github.com/EESSI/software-layer/pull/530 

SPDX license identifier: `GPL-2.0`