### PR TITLE
Fix archdetect: ensure we use instructions introduced with ARM v8.2 for Neoverse N1

### DIFF
--- a/init/arch_specs/eessi_arch_arm.spec
+++ b/init/arch_specs/eessi_arch_arm.spec
@@ -1,6 +1,6 @@
 # ARM CPU architecture specifications
-# Software path in EESSI 	| Vendor ID 	| List of defining CPU features
-"aarch64/neoverse_n1"	"ARM"		"asimd"		# Ampere Altra
-"aarch64/neoverse_n1"	""		"asimd"		# AWS Graviton2
-"aarch64/neoverse_v1"	"ARM"		"asimd svei8mm"
-"aarch64/neoverse_v1"	""		"asimd svei8mm"	# AWS Graviton3
+# ARM CPU architecture specifications (see https://gpages.juszkiewicz.com.pl/arm-socs-table/arm-socs.html for guidance)
+"aarch64/neoverse_n1"	"ARM"		"asimddp"		# Ampere Altra
+"aarch64/neoverse_n1"	""		"asimddp"		# AWS Graviton2
+"aarch64/neoverse_v1"	"ARM"		"asimddp svei8mm"
+"aarch64/neoverse_v1"	""		"asimddp svei8mm"	# AWS Graviton3

--- a/init/arch_specs/eessi_arch_arm.spec
+++ b/init/arch_specs/eessi_arch_arm.spec
@@ -1,5 +1,5 @@
-# ARM CPU architecture specifications
 # ARM CPU architecture specifications (see https://gpages.juszkiewicz.com.pl/arm-socs-table/arm-socs.html for guidance)
+# Software path in EESSI 	| Vendor ID 	| List of defining CPU features
 "aarch64/neoverse_n1"	"ARM"		"asimddp"		# Ampere Altra
 "aarch64/neoverse_n1"	""		"asimddp"		# AWS Graviton2
 "aarch64/neoverse_v1"	"ARM"		"asimddp svei8mm"


### PR DESCRIPTION
Sync NESSI with EESSI (PR 540)

On the Raspberry Pi 4, we've seen incorrect matching to Neoverse N1 due to checking an instruction that is actually available with ARM v8.0 (rather than something introduced in ARM v8.2)