### PR TITLE
{2023.06}[gompi/2023a] OSU Microbenchmarks V7.2 w/ CUDA 12.1.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -34,3 +34,4 @@ easyconfigs:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19451;
       options:
         from-pr: 19451
+  - OSU-Micro-Benchmarks-7.2-gompi-2023a-CUDA-12.1.1.eb 


### PR DESCRIPTION
Sync with EESSI (PR 487)

Lic:
```
GDRCopy/2.3.1 --> MIT 
UCX-CUDA/1.14.1 --> Similar to BSD
NCCL/2.18.3 --> BSD 
UCC-CUDA/1.2.0 --> BSD-3-Clause 
OSU-Micro-Benchmarks/7.2 --> BSD
```
```

5 out of 24 required modules missing:

* GDRCopy/2.3.1-GCCcore-12.3.0 (GDRCopy-2.3.1-GCCcore-12.3.0.eb)
* UCX-CUDA/1.14.1-GCCcore-12.3.0-CUDA-12.1.1 (UCX-CUDA-1.14.1-GCCcore-12.3.0-CUDA-12.1.1.eb)
* NCCL/2.18.3-GCCcore-12.3.0-CUDA-12.1.1 (NCCL-2.18.3-GCCcore-12.3.0-CUDA-12.1.1.eb)
* UCC-CUDA/1.2.0-GCCcore-12.3.0-CUDA-12.1.1 (UCC-CUDA-1.2.0-GCCcore-12.3.0-CUDA-12.1.1.eb)
* OSU-Micro-Benchmarks/7.2-gompi-2023a-CUDA-12.1.1 (OSU-Micro-Benchmarks-7.2-gompi-2023a-CUDA-12.1.1.eb)
```