### PR TITLE
add psm2 to filter-deps and rebuild GROMACS

### DIFF
--- a/configure_easybuild
+++ b/configure_easybuild
@@ -33,6 +33,12 @@ if [[ "$EESSI_CPU_FAMILY" == "aarch64" ]]; then
     DEPS_TO_FILTER="${DEPS_TO_FILTER},Yasm"
 fi
 
+# Version 2023.06 of NESSI ships PSM2 in the compat layer, so we can filter this out while retaining support for OFA fabric
+# (longer term this is probably not the right move as PSM2 should be configured with accelerator support, hence the restricted version)
+if [[ "$EESSI_VERSION" == "2023.06" ]]; then
+    DEPS_TO_FILTER="${DEPS_TO_FILTER},PSM2"
+fi
+
 export EASYBUILD_FILTER_DEPS=$DEPS_TO_FILTER
 
 export EASYBUILD_MODULE_EXTENSIONS=1

--- a/easystacks/pilot.nessi.no/2023.06/rebuilds/20240515-eb-4.9.1-GROMACS-correct-gmxapi-version.yml
+++ b/easystacks/pilot.nessi.no/2023.06/rebuilds/20240515-eb-4.9.1-GROMACS-correct-gmxapi-version.yml
@@ -1,0 +1,19 @@
+# 2024.05.15
+# Originally shipped version forgot to bump the gmxapi version and source
+# tarball, it was still using an older version from the 2023.3 tarball. Looking
+# at https://gitlab.com/gromacs/gromacs/-/blob/v2024.1/python_packaging/gmxapi/src/gmxapi/version.py?ref_type=tags#L68,
+# the 2024.1 release includes gmxapi 0.5.0.
+#
+# This also introduced a new build dependency on scikit-build-core for GROMACS
+#
+easyconfigs:
+  - scikit-build-core-0.9.3-GCCcore-13.2.0.eb:
+      options:
+        # from-commit: 61d07bff09afe63cfe1ae35dc58a0c8be01eed62
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20526
+        from-pr: 20526
+  - GROMACS-2024.1-foss-2023b.eb:
+      options:
+        # from-commit: a0a467a88506c765a93a96b20d7a8fcb01d46b24
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20522
+        from-pr: 20522

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -18,7 +18,7 @@ base_dir=$(dirname $(realpath $0))
 source ${base_dir}/init/eessi_defaults
 
 # Git clone has to be run in compat layer, to make the git command available
-./run_in_compat_layer_env.sh "git clone https://github.com/EESSI/test-suite EESSI-test-suite"
+./run_in_compat_layer_env.sh "git clone -b v0.2.0 https://github.com/EESSI/test-suite EESSI-test-suite"
 
 # Run the test suite
 ./test_suite.sh "$@"


### PR DESCRIPTION
Needed to fix check for missing installations. PSM2 is shipped in the compat layer, so for the moment it can be filtered from dependencies.

Also rebuilds GROMACS and adds build dependency for scikit...

Also see https://github.com/EESSI/software-layer/pull/576