### PR TITLE
Build NESSI-extend from scratch

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/rebuilds/20240520-eb-4.9.1-rebuild-NESSI-extend-module.yml
+++ b/easystacks/pilot.nessi.no/2023.06/rebuilds/20240520-eb-4.9.1-rebuild-NESSI-extend-module.yml
@@ -1,0 +1,5 @@
+# 2024-05-20
+# Rebuild NESSI-extend/2023.06-easybuild
+# Need to revert to the original version.
+easyconfigs:
+  - EESSI-extend-2023.06-easybuild.eb


### PR DESCRIPTION
Apparently, NESSI_SITE_INSTALL is intended for `.../host_injections`. So we need to rebuild the original version. We cannot just re-ingest the original tarballs because some other ingests have been done with some overlap, e.g., `SitePackage.lua`. That is, if we would only ingest the tarballs from the original PR for the NESSI-extend we would overwrite packages.