### PR TITLE
{2023.06}[foss/2023a] ABySS V2.3.7

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -35,4 +35,5 @@ easyconfigs:
       options:
         from-pr: 19451
   - cuDNN-8.9.2.26-CUDA-12.1.1.eb
-  - OSU-Micro-Benchmarks-7.2-gompi-2023a-CUDA-12.1.1.eb 
+  - OSU-Micro-Benchmarks-7.2-gompi-2023a-CUDA-12.1.1.eb
+  - ABySS-2.3.7-foss-2023a.eb


### PR DESCRIPTION
ABySS is found on SAGA

Lic : GPLv3

Missing packages :
```
3 out of 45 required modules missing:

* sparsehash/2.0.4-GCCcore-12.3.0 (sparsehash-2.0.4-GCCcore-12.3.0.eb)
* btllib/1.7.0-GCC-12.3.0 (btllib-1.7.0-GCC-12.3.0.eb)
* ABySS/2.3.7-foss-2023a (ABySS-2.3.7-foss-2023a.eb)
```