### PR TITLE
{2023.06}[gompi/2023a] BLAST+ V2.14.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -37,3 +37,4 @@ easyconfigs:
   - cuDNN-8.9.2.26-CUDA-12.1.1.eb
   - OSU-Micro-Benchmarks-7.2-gompi-2023a-CUDA-12.1.1.eb
   - ABySS-2.3.7-foss-2023a.eb
+  - BLAST+-2.14.1-gompi-2023a.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -80,4 +80,4 @@ easyconfigs:
   - tqdm-4.66.1-GCCcore-12.3.0.eb
   - BLAST+-2.14.1-gompi-2023a.eb:
       options:     
-        from-pr: 20751
+        from-pr: 20784


### PR DESCRIPTION
BLAST+ is found on SAGA 
Lic --> check NCBI licenses
```
2 out of 38 required modules missing:

* LMDB/0.9.31-GCCcore-12.3.0 (LMDB-0.9.31-GCCcore-12.3.0.eb)
* BLAST+/2.14.1-gompi-2023a (BLAST+-2.14.1-gompi-2023a.eb)
```