### PR TITLE
{2023.06}[foss/2022b] bokeh V3.2.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -3,3 +3,4 @@ easyconfigs:
   - waLBerla-6.1-foss-2022b.eb
   - R-4.2.2-foss-2022b.eb
   - WRF-4.4.1-foss-2022b-dmpar.eb
+  - bokeh-3.2.1-foss-2022b.eb


### PR DESCRIPTION
bokeh is found on Saga

Lic --> BSD
```
9 out of 76 required modules missing:

* libyaml/0.2.5-GCCcore-12.2.0 (libyaml-0.2.5-GCCcore-12.2.0.eb)
* PyYAML/6.0-GCCcore-12.2.0 (PyYAML-6.0-GCCcore-12.2.0.eb)
* cppy/1.2.1-GCCcore-12.2.0 (cppy-1.2.1-GCCcore-12.2.0.eb)
* setuptools/64.0.3-GCCcore-12.2.0 (setuptools-64.0.3-GCCcore-12.2.0.eb)
* meson-python/0.11.0-GCCcore-12.2.0 (meson-python-0.11.0-GCCcore-12.2.0.eb)
* Pillow/9.4.0-GCCcore-12.2.0 (Pillow-9.4.0-GCCcore-12.2.0.eb)
* Tkinter/3.10.8-GCCcore-12.2.0 (Tkinter-3.10.8-GCCcore-12.2.0.eb)
* matplotlib/3.7.0-gfbf-2022b (matplotlib-3.7.0-gfbf-2022b.eb)
* bokeh/3.2.1-foss-2022b (bokeh-3.2.1-foss-2022b.eb)
```