### PR TITLE
{2023.06}[foss/2022b] MDAnalysis V2.4.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -4,3 +4,4 @@ easyconfigs:
   - R-4.2.2-foss-2022b.eb
   - WRF-4.4.1-foss-2022b-dmpar.eb
   - bokeh-3.2.1-foss-2022b.eb
+  - MDAnalysis-2.4.2-foss-2022b.eb


### PR DESCRIPTION
MDAnalysis-2.4.2 is found on Saga

Lic --> GPLv3+

```
4 out of 75 required modules missing:

* tqdm/4.64.1-GCCcore-12.2.0 (tqdm-4.64.1-GCCcore-12.2.0.eb)
* networkx/3.0-gfbf-2022b (networkx-3.0-gfbf-2022b.eb)
* Biopython/1.81-foss-2022b (Biopython-1.81-foss-2022b.eb)
* MDAnalysis/2.4.2-foss-2022b (MDAnalysis-2.4.2-foss-2022b.eb)
```