### PR TITLE
{2023.06}[gompi/2022b] prokka V1.14.5

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -5,3 +5,4 @@ easyconfigs:
   - WRF-4.4.1-foss-2022b-dmpar.eb
   - bokeh-3.2.1-foss-2022b.eb
   - MDAnalysis-2.4.2-foss-2022b.eb
+  - prokka-1.14.5-gompi-2022b.eb


### PR DESCRIPTION
prokka is found on Saga

Lic --> GPLv2
```
8 out of 49 required modules missing:

* tbl2asn/20230713-linux64 (tbl2asn-20230713-linux64.eb)
* XML-LibXML/2.0208-GCCcore-12.2.0 (XML-LibXML-2.0208-GCCcore-12.2.0.eb)
* parallel/20230722-GCCcore-12.2.0 (parallel-20230722-GCCcore-12.2.0.eb)
* BioPerl/1.7.8-GCCcore-12.2.0 (BioPerl-1.7.8-GCCcore-12.2.0.eb)
* Bio-SearchIO-hmmer/1.7.3-GCC-12.2.0 (Bio-SearchIO-hmmer-1.7.3-GCC-12.2.0.eb)
* LMDB/0.9.29-GCCcore-12.2.0 (LMDB-0.9.29-GCCcore-12.2.0.eb)
* BLAST+/2.14.0-gompi-2022b (BLAST+-2.14.0-gompi-2022b.eb)
* prokka/1.14.5-gompi-2022b (prokka-1.14.5-gompi-2022b.eb)
```