### PR TITLE
{2023.06}[foss/2023a] WhatsHap V2.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -39,3 +39,4 @@ easyconfigs:
   - Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb:
       options:     
         from-pr: 20540
+  - WhatsHap-2.2-foss-2023a.eb


### PR DESCRIPTION
WhatsHap V2.2 is found on Saga

Lic --> MIT
```
6 out of 64 required modules missing:

* pyfaidx/0.8.1.1-GCCcore-12.3.0 (pyfaidx-0.8.1.1-GCCcore-12.3.0.eb)
* ISA-L/2.30.0-GCCcore-12.3.0 (ISA-L-2.30.0-GCCcore-12.3.0.eb)
* python-isal/1.1.0-GCCcore-12.3.0 (python-isal-1.1.0-GCCcore-12.3.0.eb)
* Pysam/0.22.0-GCC-12.3.0 (Pysam-0.22.0-GCC-12.3.0.eb)
* Biopython/1.83-foss-2023a (Biopython-1.83-foss-2023a.eb)
* WhatsHap/2.2-foss-2023a (WhatsHap-2.2-foss-2023a.eb)

```