### PR TITLE
{2023.06}[foss/2022b] arrow-R V4.2.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -5,3 +5,4 @@ easyconfigs:
   - WRF-4.4.1-foss-2022b-dmpar.eb
   - bokeh-3.2.1-foss-2022b.eb
   - MDAnalysis-2.4.2-foss-2022b.eb
+  - arrow-R-11.0.0.3-foss-2022b-R-4.2.2.eb


### PR DESCRIPTION
Arrow is found on Saga 
Lic --> Apache License (>= 2.0)
```
5 out of 146 required modules missing:

* RapidJSON/1.1.0-GCCcore-12.2.0 (RapidJSON-1.1.0-GCCcore-12.2.0.eb)
* RE2/2023-03-01-GCCcore-12.2.0 (RE2-2023-03-01-GCCcore-12.2.0.eb)
* utf8proc/2.8.0-GCCcore-12.2.0 (utf8proc-2.8.0-GCCcore-12.2.0.eb)
* Arrow/11.0.0-gfbf-2022b (Arrow-11.0.0-gfbf-2022b.eb)
* arrow-R/11.0.0.3-foss-2022b-R-4.2.2 (arrow-R-11.0.0.3-foss-2022b-R-4.2.2.eb)
```



