### PR TITLE
{2023.06}[system] Nextflow v23.10.0

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-001-system.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-001-system.yml
@@ -5,3 +5,4 @@ easyconfigs:
   - EESSI-extend-2023.06-easybuild.eb
   - cuDNN-8.9.2.26-CUDA-12.1.1.eb
   - cuTENSOR-2.0.1.2-CUDA-12.1.1.eb
+  - Nextflow-23.10.0.eb


### PR DESCRIPTION
Adding Nextflow to NESSI/2023.06

SPDX license identifier: `Apache-2.0`

Missing packages:
```
1 out of 3 required modules missing:

* Nextflow/23.10.0 (Nextflow-23.10.0.eb)
```
