### PR TITLE
{2023.06}[foss/2023b] netCDF-Fortran v4.6.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
@@ -23,3 +23,4 @@ easyconfigs:
       options:
         from-pr: 20439
   - GDB-13.2-GCCcore-13.2.0.eb
+  - netCDF-Fortran-4.6.1-gompi-2023b.eb


### PR DESCRIPTION
Add package available on Saga.

SPDX license identifier:

Missing packages: