### PR TITLE
{2023.06}[foss/2022b] ParaView V5.11.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -6,3 +6,4 @@ easyconfigs:
   - bokeh-3.2.1-foss-2022b.eb
   - MDAnalysis-2.4.2-foss-2022b.eb
   - arrow-R-11.0.0.3-foss-2022b-R-4.2.2.eb
+  - ParaView-5.11.1-foss-2022b.eb


### PR DESCRIPTION
ParaView/5.11.1 is found in Saga

lic --> permissive BSD 3-Clause
```
6 out of 99 required modules missing:

* x264/20230226-GCCcore-12.2.0 (x264-20230226-GCCcore-12.2.0.eb)
* Yasm/1.3.0-GCCcore-12.2.0 (Yasm-1.3.0-GCCcore-12.2.0.eb)
* x265/3.5-GCCcore-12.2.0 (x265-3.5-GCCcore-12.2.0.eb)
* SDL2/2.26.3-GCCcore-12.2.0 (SDL2-2.26.3-GCCcore-12.2.0.eb)
* FFmpeg/5.1.2-GCCcore-12.2.0 (FFmpeg-5.1.2-GCCcore-12.2.0.eb)
* ParaView/5.11.1-foss-2022b (ParaView-5.11.1-foss-2022b.eb)

```