### PR TITLE
{2023.06}[foss/2022b] biom-format V2.1.15

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -6,3 +6,4 @@ easyconfigs:
   - bokeh-3.2.1-foss-2022b.eb
   - MDAnalysis-2.4.2-foss-2022b.eb
   - arrow-R-11.0.0.3-foss-2022b-R-4.2.2.eb
+  - biom-format-2.1.15-foss-2022b.eb


### PR DESCRIPTION
biom-format/2.1.15 is found on Saga

Lic --> New or Revised BSD

```
4 out of 55 required modules missing:

* pkgconfig/1.5.5-GCCcore-12.2.0-python (pkgconfig-1.5.5-GCCcore-12.2.0-python.eb)
* mpi4py/3.1.4-gompi-2022b (mpi4py-3.1.4-gompi-2022b.eb)
* h5py/3.8.0-foss-2022b (h5py-3.8.0-foss-2022b.eb)
* biom-format/2.1.15-foss-2022b (biom-format-2.1.15-foss-2022b.eb)

```