### PR TITLE
{2023.06}[foss/2023a] GATK v4.5.0.0

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -40,3 +40,4 @@ easyconfigs:
       options:     
         from-pr: 20540
   - WhatsHap-2.2-foss-2023a.eb
+  - GATK-4.5.0.0-GCCcore-12.3.0-Java-17.eb


### PR DESCRIPTION
Add GATK v4.5.0.0

SPDX license identifier: `Apache-2.0`

Missing packages:
```
3 out of 12 required modules missing:

* Java/17.0.6 (Java-17.0.6.eb)
* Java/17 (Java-17.eb)
* GATK/4.5.0.0-GCCcore-12.3.0-Java-17 (GATK-4.5.0.0-GCCcore-12.3.0-Java-17.eb)
```
