### PR TITLE
{2023.06}[foss/2022b] R-bundle-Bioconductor V3.16 R V4.2.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -7,4 +7,6 @@ easyconfigs:
   - MDAnalysis-2.4.2-foss-2022b.eb
   - arrow-R-11.0.0.3-foss-2022b-R-4.2.2.eb
   - biom-format-2.1.15-foss-2022b.eb
-  - R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb
+  - R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb:
+      options:
+        from-pr: 20379

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -7,3 +7,4 @@ easyconfigs:
   - MDAnalysis-2.4.2-foss-2022b.eb
   - arrow-R-11.0.0.3-foss-2022b-R-4.2.2.eb
   - biom-format-2.1.15-foss-2022b.eb
+  - R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb


### PR DESCRIPTION
R-bundle-Bioconductor/3.16-R-4.2.2 is found on Saga
Lic -->  Artistic-2.0
```
1 out of 147 required modules missing:

* R-bundle-Bioconductor/3.16-foss-2022b-R-4.2.2 (R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb)
```