### PR TITLE
{2023.06}[gfbf/2022b] ASE V3.22.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -7,3 +7,4 @@ easyconfigs:
   - MDAnalysis-2.4.2-foss-2022b.eb
   - arrow-R-11.0.0.3-foss-2022b-R-4.2.2.eb
   - biom-format-2.1.15-foss-2022b.eb
+  - ASE-3.22.1-gfbf-2022b.eb


### PR DESCRIPTION
ASE-3.22.1 is found on Saga:

Lic --> LGPL

```
3 out of 61 required modules missing:

* Flask/2.2.3-GCCcore-12.2.0 (Flask-2.2.3-GCCcore-12.2.0.eb)
* spglib-python/2.0.2-gfbf-2022b (spglib-python-2.0.2-gfbf-2022b.eb)
* ASE/3.22.1-gfbf-2022b (ASE-3.22.1-gfbf-2022b.eb)

```