### PR TITLE
{2023.06}[foss/2023a] ESPResSo V4.2.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -49,3 +49,6 @@ easyconfigs:
         from-pr: 20540
   - WhatsHap-2.2-foss-2023a.eb
   - GATK-4.5.0.0-GCCcore-12.3.0-Java-17.eb
+  - ESPResSo-4.2.2-foss-2023a.eb:
+      options:
+        from-pr: 20595


### PR DESCRIPTION
Sync with EESSI PR 584
Lic --> GPL

```
1 out of 87 required modules missing:

* ESPResSo/4.2.2-foss-2023a (ESPResSo-4.2.2-foss-2023a.eb)
```