### PR TITLE
{2023.06}[foss/2023a] OpenFOAM V2312

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -57,4 +57,5 @@ easyconfigs:
         cuda-compute-capabilities: 6.0,6.1,7.0,7.5,8.0,8.6,8.9,9.0
   - OpenFOAM-v2312-foss-2023a.eb:
       options:
+        include-easyblocks-from-pr: 3328
         from-pr: 20517

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -55,3 +55,4 @@ easyconfigs:
   - PyTorch-2.1.2-foss-2023a-CUDA-12.1.1.eb:
       options:
         cuda-compute-capabilities: 6.0,6.1,7.0,7.5,8.0,8.6,8.9,9.0
+  - OpenFOAM-v2312-foss-2023a.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -55,7 +55,4 @@ easyconfigs:
   - PyTorch-2.1.2-foss-2023a-CUDA-12.1.1.eb:
       options:
         cuda-compute-capabilities: 6.0,6.1,7.0,7.5,8.0,8.6,8.9,9.0
-  - OpenFOAM-v2312-foss-2023a.eb:
-      options:
-        include-easyblocks-from-pr: 3328
-        from-pr: 20517
+  - OpenFOAM-v2312-foss-2023a.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -55,4 +55,6 @@ easyconfigs:
   - PyTorch-2.1.2-foss-2023a-CUDA-12.1.1.eb:
       options:
         cuda-compute-capabilities: 6.0,6.1,7.0,7.5,8.0,8.6,8.9,9.0
-  - OpenFOAM-v2312-foss-2023a.eb
+  - OpenFOAM-v2312-foss-2023a.eb:
+      options:
+        from-pr: 20517


### PR DESCRIPTION
OpenFOAM-v2312 is found on Saga

Lic --> GPL
```
2 out of 114 required modules missing:

* KaHIP/3.16-gompi-2023a (KaHIP-3.16-gompi-2023a.eb)
* OpenFOAM/v2312-foss-2023a (OpenFOAM-v2312-foss-2023a.eb)

```