### PR TITLE
{2023.06}[foss/2022b] SEPP V4.5.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -12,3 +12,4 @@ easyconfigs:
       options:
         from-pr: 20379
   - ParaView-5.11.1-foss-2022b.eb
+  - SEPP-4.5.1-foss-2022b.eb


### PR DESCRIPTION
SEPP-4.5.1 is found on Saga: 
lic --> GPL
```

2 out of 43 required modules missing:

* DendroPy/4.5.2-GCCcore-12.2.0 (DendroPy-4.5.2-GCCcore-12.2.0.eb)
* SEPP/4.5.1-foss-2022b (SEPP-4.5.1-foss-2022b.eb)

```