### PR TITLE
{2023.06}[foss/2023b] NLTK V3.8.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
@@ -25,3 +25,4 @@ easyconfigs:
   - GDB-13.2-GCCcore-13.2.0.eb
   - IPython-8.17.2-GCCcore-13.2.0.eb
   - Qt5-5.15.13-GCCcore-13.2.0.eb
+  - NLTK-3.8.1-foss-2023b.eb


### PR DESCRIPTION
Lic --> Apache License 2.0

```
3 out of 85 required modules missing:

* tqdm/4.66.2-GCCcore-13.2.0 (tqdm-4.66.2-GCCcore-13.2.0.eb)
* scikit-learn/1.4.0-gfbf-2023b (scikit-learn-1.4.0-gfbf-2023b.eb)
* NLTK/3.8.1-foss-2023b (NLTK-3.8.1-foss-2023b.eb)
```