### PR TITLE
{2023.06}[foss/2023a] bx-python V0.10.0

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -55,3 +55,4 @@ easyconfigs:
   - PyTorch-2.1.2-foss-2023a-CUDA-12.1.1.eb:
       options:
         cuda-compute-capabilities: 6.0,6.1,7.0,7.5,8.0,8.6,8.9,9.0
+  - bx-python-0.10.0-foss-2023a.eb


### PR DESCRIPTION
bx-python-0.10.0 is found on Saga:
Lic --> MIT
```
2 out of 57 required modules missing:

* LZO/2.10-GCCcore-12.3.0 (LZO-2.10-GCCcore-12.3.0.eb)
* bx-python/0.10.0-foss-2023a (bx-python-0.10.0-foss-2023a.eb)

```