### PR TITLE
{2023.06,2023a} dependencies for PyTorch-bundle v2.1.2

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -266,15 +266,19 @@ mkdir -p ${TARBALL_TMP_BUILD_STEP_DIR}
 BUILD_STEP_ARGS+=("--save" "${TARBALL_TMP_BUILD_STEP_DIR}")
 BUILD_STEP_ARGS+=("--storage" "${STORAGE}")
 # add options required to handle NVIDIA support
-BUILD_STEP_ARGS+=("--nvidia" "all")
+if command_exists "nvidia-smi"; then
+    echo "Command 'nvidia-smi' found, using available GPU"
+    BUILD_STEP_ARGS+=("--nvidia" "all")
+else
+    echo "No 'nvidia-smi' found, no available GPU but allowing overriding this check"
+    BUILD_STEP_ARGS+=("--nvidia" "install")
+fi
+# Retain location for host injections so we don't reinstall CUDA
+# (Always need to run the driver installation as available driver may change)
+
 if [[ ! -z ${SHARED_FS_PATH} ]]; then
     BUILD_STEP_ARGS+=("--host-injections" "${SHARED_FS_PATH}/host-injections")
 fi
-
-# Don't run the Lmod GPU driver check when doing builds (may not have a GPU, and it's not relevant for vanilla builds anyway)
-echo "EESSI_OVERRIDE_GPU_CHECK='${EESSI_OVERRIDE_GPU_CHECK}'"
-export EESSI_OVERRIDE_GPU_CHECK=1
-echo "EESSI_OVERRIDE_GPU_CHECK='${EESSI_OVERRIDE_GPU_CHECK}'"
 
 # create tmp file for output of build step
 build_outerr=$(mktemp build.outerr.XXXX)

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -55,3 +55,23 @@ easyconfigs:
   - PyTorch-2.1.2-foss-2023a-CUDA-12.1.1.eb:
       options:
         cuda-compute-capabilities: 6.0,6.1,7.0,7.5,8.0,8.6,8.9,9.0
+  # PyTorch-bundle-CUDA's dependencies without CUDA
+  - librosa-0.10.1-foss-2023a.eb
+  - NLTK-3.8.1-foss-2023a.eb
+  - parameterized-0.9.0-GCCcore-12.3.0.eb
+  - Scalene-1.5.26-GCCcore-12.3.0.eb
+  - scikit-image-0.22.0-foss-2023a.eb
+  - SentencePiece-0.2.0-GCC-12.3.0.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19987
+      options:
+        from-pr: 19987
+  - libmad-0.15.1b-GCCcore-12.3.0.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19987
+      options:
+        from-pr: 19987
+  - SoX-14.4.2-GCCcore-12.3.0.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19987
+      options:
+        from-pr: 19987
+  - tensorboard-2.15.1-gfbf-2023a.eb
+  - tqdm-4.66.1-GCCcore-12.3.0.eb

--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -477,6 +477,11 @@ if [[ ${SETUP_NVIDIA} -eq 1 ]]; then
         mkdir -p ${EESSI_USR_LOCAL_CUDA}
         BIND_PATHS="${BIND_PATHS},${EESSI_VAR_LOG}:/var/log,${EESSI_USR_LOCAL_CUDA}:/usr/local/cuda"
         [[ ${VERBOSE} -eq 1 ]] && echo "BIND_PATHS=${BIND_PATHS}"
+        if [[ "${NVIDIA_MODE}" == "install" ]] ; then
+            # No GPU so we need to "trick" Lmod to allow us to load CUDA modules even without a CUDA driver
+            # (this variable means EESSI_OVERRIDE_GPU_CHECK=1 will be set inside the container)
+            export SINGULARITYENV_EESSI_OVERRIDE_GPU_CHECK=1
+        fi
     fi
 fi
 

--- a/install_scripts.sh
+++ b/install_scripts.sh
@@ -113,6 +113,7 @@ nvidia_files=(
     eessi-2023.06-cuda-and-libraries.yml
     install_cuda_and_libraries.sh
     link_nvidia_host_libraries.sh
+    copy_nvidia_host_libraries.sh
 )
 copy_files_by_list ${TOPDIR}/scripts/gpu_support/nvidia ${INSTALL_PREFIX}/scripts/gpu_support/nvidia "${nvidia_files[@]}"
 

--- a/run_in_compat_layer_env.sh
+++ b/run_in_compat_layer_env.sh
@@ -26,11 +26,11 @@ fi
 if [ ! -z ${EESSI_VERSION_OVERRIDE} ]; then
     INPUT="export EESSI_VERSION_OVERRIDE=${EESSI_VERSION_OVERRIDE}; ${INPUT}"
 fi
-if [ ! -z ${http_proxy} ]; then
-    INPUT="export http_proxy=${http_proxy}; ${INPUT}"
-fi
 if [ ! -z ${EESSI_OVERRIDE_GPU_CHECK} ]; then
     INPUT="export EESSI_OVERRIDE_GPU_CHECK=${EESSI_OVERRIDE_GPU_CHECK}; ${INPUT}"
+fi
+if [ ! -z ${http_proxy} ]; then
+    INPUT="export http_proxy=${http_proxy}; ${INPUT}"
 fi
 if [ ! -z ${https_proxy} ]; then
     INPUT="export https_proxy=${https_proxy}; ${INPUT}"

--- a/scripts/extra/custom_ctypes-1.2.eb
+++ b/scripts/extra/custom_ctypes-1.2.eb
@@ -1,0 +1,29 @@
+##
+# This is a contribution from the NESSI project
+# Homepage: 	https://documentation.sigma2.no
+#
+# Authors::	Thomas Roeblitz <thomas.roblitz@uib.no>
+# License::	GPL-2.0-only
+#
+##
+
+easyblock = 'Tarball'
+
+name = 'custom_ctypes'
+version = '1.2'
+
+homepage = 'https://github.com/ComputeCanada/custom_ctypes'
+description = """custum_ctypes is a small Python package to fix the discovery of libraries with Python's ctypes module. It changes the behavior of find_library to return absolute paths to shared objects rather than just the names."""
+
+toolchain = SYSTEM
+
+source_urls = ['https://github.com/ComputeCanada/custom_ctypes/archive/refs/tags']
+sources = ['%(version)s.tar.gz']
+checksums = ['3b30ce633c6a329169f2b10ff24b8eaaeef3fa208a66cdacdb53c22f02a88d9b']
+
+sanity_check_paths = {
+    'files': ['README.md'],
+    'dirs': ['lib'],
+}
+
+moduleclass = 'lib'

--- a/scripts/extra/eessi-2023.06-extra-packages.yml
+++ b/scripts/extra/eessi-2023.06-extra-packages.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - custom_ctypes-1.2.eb

--- a/scripts/extra/install_extra_packages.sh
+++ b/scripts/extra/install_extra_packages.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# This script can be used to install extra packages under ${EESSI_SOFTWARE_PATH}
+
+# some logging
+echo ">>> Running ${BASH_SOURCE}"
+
+# Initialise our bash functions
+TOPDIR=$(dirname $(realpath ${BASH_SOURCE}))
+source "${TOPDIR}"/../utils.sh
+
+# Function to display help message
+show_help() {
+    echo "Usage: $0 [OPTIONS]"
+    echo "Options:"
+    echo "  --help                           Display this help message"
+    echo "  -e, --easystack EASYSTACKFILE    Easystack file which specifies easyconfigs to be installed."
+    echo "  -t, --temp-dir /path/to/tmpdir   Specify a location to use for temporary"
+    echo "                                   storage during the installation"
+}
+
+# Initialize variables
+TEMP_DIR=
+EASYSTACK_FILE=
+
+# Parse command-line options
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help)
+            show_help
+            exit 0
+            ;;
+        -e|--easystack)
+            if [ -n "$2" ]; then
+                EASYSTACK_FILE="$2"
+                shift 2
+            else
+                echo "Error: Argument required for $1"
+                show_help
+                exit 1
+            fi
+            ;;
+        -t|--temp-dir)
+            if [ -n "$2" ]; then
+                TEMP_DIR="$2"
+                shift 2
+            else
+                echo "Error: Argument required for $1"
+                show_help
+                exit 1
+            fi
+            ;;
+        *)
+            show_help
+            fatal_error "Error: Unknown option: $1"
+            ;;
+    esac
+done
+
+if [[ -z ${EASYSTACK_FILE} ]]; then
+    show_help
+    fatal_error "Error: need to specify easystack file"
+fi
+
+# Make sure NESSI is initialised
+check_eessi_initialised
+
+# As an installation location just use $EESSI_SOFTWARE_PATH
+export NESSI_CVMFS_INSTALL=${EESSI_SOFTWARE_PATH}
+
+# we need a directory we can use for temporary storage
+if [[ -z "${TEMP_DIR}" ]]; then
+    tmpdir=$(mktemp -d)
+else
+    mkdir -p ${TEMP_DIR}
+    tmpdir=$(mktemp -d --tmpdir=${TEMP_DIR} extra.XXX)
+    if [[ ! -d "$tmpdir" ]] ; then
+        fatal_error "Could not create directory ${tmpdir}"
+    fi
+fi
+echo "Created temporary directory '${tmpdir}'"
+export WORKING_DIR=${tmpdir}
+
+# load EasyBuild
+ml EasyBuild
+
+# load NESSI-extend/2023.06-easybuild
+ml NESSI-extend/2023.06-easybuild
+
+eb --show-config
+
+eb --easystack ${EASYSTACK_FILE} --robot
+
+# clean up tmpdir
+rm -rf "${tmpdir}"

--- a/scripts/gpu_support/nvidia/copy_nvidia_host_libraries.sh
+++ b/scripts/gpu_support/nvidia/copy_nvidia_host_libraries.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# This script links host libraries related to GPU drivers to a location where
+# they can be found by the EESSI linker
+
+# Initialise our bash functions
+TOPDIR=$(dirname $(realpath $BASH_SOURCE))
+source "$TOPDIR"/../../utils.sh
+
+# We rely on ldconfig to give us the location of the libraries on the host
+command_name="ldconfig"
+# We cannot use a version of ldconfig that's being shipped under CVMFS
+exclude_prefix="/cvmfs"
+
+found_paths=()
+# Always attempt to use /sbin/ldconfig
+if [ -x "/sbin/$command_name" ]; then
+    found_paths+=("/sbin/$command_name")
+fi
+IFS=':' read -ra path_dirs <<< "$PATH"
+for dir in "${path_dirs[@]}"; do
+  if [ "$dir" = "/sbin" ]; then
+    continue  # we've already checked for $command_name in /sbin, don't need to do it twice
+  fi
+  if [[ ! "$dir" =~ ^$exclude_prefix ]]; then
+      if [ -x "$dir/$command_name" ]; then
+          found_paths+=("$dir/$command_name")
+      fi
+  fi
+done
+
+if [ ${#found_paths[@]} -gt 0 ]; then
+    echo "Found $command_name in the following locations:"
+    printf -- "- %s\n" "${found_paths[@]}"
+    echo "Using first version"
+    host_ldconfig=${found_paths[0]}
+else
+    error="$command_name not found in PATH or only found in paths starting with $exclude_prefix."
+    fatal_error "$error"
+fi
+
+# Make sure EESSI is initialised (doesn't matter what version)
+check_eessi_initialised
+
+# Find the CUDA version of the host CUDA drivers
+# (making sure that this can still work inside prefix environment inside a container)
+export LD_LIBRARY_PATH=/.singularity.d/libs:$LD_LIBRARY_PATH
+nvidia_smi_command="nvidia-smi --query-gpu=driver_version --format=csv,noheader"
+if $nvidia_smi_command > /dev/null; then
+  host_driver_version=$($nvidia_smi_command | tail -n1)
+  echo_green "Found NVIDIA GPU driver version ${host_driver_version}"
+  # If the first worked, this should work too
+  host_cuda_version=$(nvidia-smi  -q --display=COMPUTE | grep CUDA | awk 'NF>1{print $NF}')
+  echo_green "Found host CUDA version ${host_cuda_version}"
+else
+  error="Failed to successfully execute\n  $nvidia_smi_command\n"
+  fatal_error "$error"
+fi
+
+# Let's make sure the driver libraries are not already in place
+link_drivers=1
+
+# first make sure that target of host_injections variant symlink is an existing directory
+host_injections_target=$(realpath -m ${EESSI_CVMFS_REPO}/host_injections)
+if [ ! -d ${host_injections_target} ]; then
+    create_directory_structure ${host_injections_target}
+fi
+
+host_injections_nvidia_dir="${EESSI_CVMFS_REPO}/host_injections/nvidia/${EESSI_CPU_FAMILY}"
+host_injection_driver_dir="${host_injections_nvidia_dir}/host"
+host_injection_driver_version_file="$host_injection_driver_dir/driver_version.txt"
+if [ -e "$host_injection_driver_version_file" ]; then
+  if grep -q "$host_driver_version" "$host_injection_driver_version_file"; then
+    echo_green "The host GPU driver libraries (v${host_driver_version}) have already been linked! (based on ${host_injection_driver_version_file})"
+    link_drivers=0
+  else
+    # There's something there but it is out of date
+    echo_yellow "Cleaning out outdated symlinks"
+    rm $host_injection_driver_dir/*
+    if [ $? -ne 0 ]; then
+      error="Unable to remove files under '$host_injection_driver_dir'."
+      fatal_error "$error"
+    fi
+  fi
+fi
+
+drivers_linked=0
+if [ "$link_drivers" -eq 1 ]; then
+  if ! create_directory_structure "${host_injection_driver_dir}" ; then
+    fatal_error "No write permissions to directory ${host_injection_driver_dir}"
+  fi
+  cd ${host_injection_driver_dir}
+  # Need a small temporary space to hold a couple of files
+  temp_dir=$(mktemp -d)
+  echo "temp_dir: '${temp_dir}'"
+
+  # Gather libraries on the host (_must_ be host ldconfig)
+  $host_ldconfig -p | awk '{print $NF}' > "$temp_dir"/libs.txt
+  # Allow for the fact that we may be in a container so the CUDA libs might be in there
+  ls /.singularity.d/libs/* >> "$temp_dir"/libs.txt 2>/dev/null
+
+  # Leverage singularity to find the full list of libraries we should be linking to
+  echo_yellow "Downloading latest version of nvliblist.conf from Apptainer to ${temp_dir}/nvliblist.conf"
+  curl --silent --output "$temp_dir"/nvliblist.conf https://raw.githubusercontent.com/apptainer/apptainer/main/etc/nvliblist.conf
+
+  # Make symlinks to all the interesting libraries
+  grep '.so$' "$temp_dir"/nvliblist.conf | xargs -i grep {} "$temp_dir"/libs.txt | xargs -i cp -a {} ${host_injection_driver_dir}/.
+
+  # Inject driver and CUDA versions into dir
+  echo $host_driver_version > driver_version.txt
+  echo $host_cuda_version > cuda_version.txt
+  drivers_linked=1
+
+  # Remove the temporary directory when done
+  rm -r "$temp_dir"
+fi
+
+# Make latest symlink for NVIDIA drivers
+cd $host_injections_nvidia_dir
+symlink="latest"
+if [ -L "$symlink" ]; then
+    # Unless the drivers have been installed, leave the symlink alone
+    if [ "$drivers_linked" -eq 1 ]; then
+      ln -sf host latest
+    fi
+else
+    # No link exists yet
+    ln -s host latest
+fi
+
+# Make sure the libraries can be found by the EESSI linker
+host_injection_linker_dir=${EESSI_EPREFIX/versions/host_injections}
+if [ -L "$host_injection_linker_dir/lib" ]; then
+  target_path=$(readlink -f "$host_injection_linker_dir/lib")
+  if [ "$target_path" != "$$host_injections_nvidia_dir/latest" ]; then
+    cd $host_injection_linker_dir
+    ln -sf $host_injections_nvidia_dir/latest lib
+  fi
+else
+  create_directory_structure $host_injection_linker_dir
+  cd $host_injection_linker_dir
+  ln -s $host_injections_nvidia_dir/latest lib
+fi
+
+echo_green "Host NVIDIA GPU drivers linked successfully for EESSI"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -78,6 +78,11 @@ function create_directory_structure() {
   return $return_code
 }
 
+# function to check if a command exists
+function command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
 function get_path_for_tool {
     tool_name=$1
     tool_envvar_name=$2


### PR DESCRIPTION
Dependencies for PyTorch-bundle with several fixes that work around issues we found while building the whole package (PyTorch-bundle). Since the whole bundle fails in some tests, we aim at reducing build time building all dependencies first.

SPDX license identifiers: various

Missing packages:

```
14 out of ? required modules missing:

* LLVM/14.0.6-GCCcore-12.3.0-llvmlite (LLVM-14.0.6-GCCcore-12.3.0-llvmlite.eb)
* numba/0.58.1-foss-2023a (numba-0.58.1-foss-2023a.eb)
* librosa/0.10.1-foss-2023a (librosa-0.10.1-foss-2023a.eb)
* NLTK/3.8.1-foss-2023a (NLTK-3.8.1-foss-2023a.eb)
* parameterized/0.9.0-GCCcore-12.3.0 (parameterized-0.9.0-GCCcore-12.3.0.eb)
* Scalene/1.5.26-GCCcore-12.3.0 (Scalene-1.5.26-GCCcore-12.3.0.eb)
* imageio/2.33.1-gfbf-2023a (imageio-2.33.1-gfbf-2023a.eb)
* scikit-image/0.22.0-foss-2023a (scikit-image-0.22.0-foss-2023a.eb)
* gperftools/2.12-GCCcore-12.3.0 (gperftools-2.12-GCCcore-12.3.0.eb)
* SentencePiece/0.2.0-GCC-12.3.0 (SentencePiece-0.2.0-GCC-12.3.0.eb)
* libmad/0.15.1b-GCCcore-12.3.0 (libmad-0.15.1b-GCCcore-12.3.0.eb)
* SoX/14.4.2-GCCcore-12.3.0 (SoX-14.4.2-GCCcore-12.3.0.eb)
* tensorboard/2.15.1-gfbf-2023a (tensorboard-2.15.1-gfbf-2023a.eb)
* tqdm/4.66.1-GCCcore-12.3.0 (tqdm-4.66.1-GCCcore-12.3.0.eb)
```

Note, the PR will also install `custom_ctypes/1.2`