### PR TITLE
Use default memory option during reframe tests

### DIFF
--- a/test_suite.sh
+++ b/test_suite.sh
@@ -177,7 +177,8 @@ sed -i "s/__NUM_CPUS__/${cpu_count}/g" $RFM_CONFIG_FILES
 sed -i "s/__NUM_SOCKETS__/${socket_count}/g" $RFM_CONFIG_FILES
 sed -i "s/__NUM_CPUS_PER_CORE__/${threads_per_core}/g" $RFM_CONFIG_FILES
 sed -i "s/__NUM_CPUS_PER_SOCKET__/${cores_per_socket}/g" $RFM_CONFIG_FILES
-sed -i "s/__MEM_PER_NODE__/${cgroup_mem_mib}/g" $RFM_CONFIG_FILES
+# on local systems the change below is not the case, it works on AWS
+# sed -i "s/__MEM_PER_NODE__/${cgroup_mem_mib}/g" $RFM_CONFIG_FILES
 
 # Workaround for https://github.com/EESSI/software-layer/pull/467#issuecomment-1973341966
 export PSM3_DEVICES='self,shm'  # this is enough, since we only run single node for now


### PR DESCRIPTION
Reverting back to the old memory config during ReFrame tests as the config is only applicable on AWS builds