### PR TITLE
Use default memory option during reframe tests

### DIFF
--- a/test_suite.sh
+++ b/test_suite.sh
@@ -165,7 +165,7 @@ if [[ "${cpuinfo}" =~ (Core\(s\) per socket:[^0-9]*([0-9]+)) ]]; then
 else
     fatal_error "Failed to get the number of cores per socket for the current test hardware with lscpu."
 fi
-cgroup_mem_bytes=$(cat /hostsys/fs/cgroup/memory/slurm/uid_${UID}/job_${SLURM_JOB_ID}/memory.limit_in_bytes)
+# cgroup_mem_bytes=$(cat /hostsys/fs/cgroup/memory/slurm/uid_${UID}/job_${SLURM_JOB_ID}/memory.limit_in_bytes)
 if [[ $? -eq 0 ]]; then
     # Convert to MiB
     cgroup_mem_mib=$((cgroup_mem_bytes/(1024*1024)))


### PR DESCRIPTION
Reverting back to old memory options during ReFrame test.