### PR TITLE
{2023.06}[gompi/2023b] dlb V3.4

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - dlb-3.4-gompi-2023b.eb


### PR DESCRIPTION
lic --> GPL-3.0 license

```
missing packages: 

dlb/3.4-gompi-2023b
```