### PR TITLE
{2023.06}[GCC/12.3.0] BCFtools V1.18

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - grpcio-1.57.0-GCCcore-12.3.0.eb
+  - BCFtools-1.18-GCC-12.3.0.eb


### PR DESCRIPTION
BCFtools V1.18 is available on SAGA:
lic -->  MIT/Expat license or the GNU General Public License (GPL)
```
1 out of 8 required modules missing:

* BCFtools/1.18-GCC-12.3.0 (BCFtools-1.18-GCC-12.3.0.eb)
```