### PR TITLE
{2023.06}[gompi/2023a] bio-packages - set1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -1,3 +1,19 @@
 easyconfigs:
   - grpcio-1.57.0-GCCcore-12.3.0.eb
   - BCFtools-1.18-GCC-12.3.0.eb
+  - BWA-0.7.17-GCCcore-12.3.0.eb
+  - CapnProto-1.0.1-GCCcore-12.3.0.eb
+  - DendroPy-4.6.1-GCCcore-12.3.0.eb
+  - DIAMOND-2.1.8-GCC-12.3.0.eb
+  - FastME-2.1.6.3-GCC-12.3.0.eb
+  - fastp-0.23.4-GCC-12.3.0.eb
+  - HMMER-3.4-gompi-2023a.eb
+  - IQ-TREE-2.2.2.7-gompi-2023a.eb
+  - KronaTools-2.8.1-GCCcore-12.3.0.eb
+  - LSD2-2.4.1-GCCcore-12.3.0.eb
+  - MAFFT-7.520-GCC-12.3.0-with-extensions.eb
+  - MEGAHIT-1.2.9-GCCcore-12.3.0.eb
+  - minimap2-2.26-GCCcore-12.3.0.eb
+  - MMseqs2-14-7e284-gompi-2023a.eb
+  - ncbi-vdb-3.0.10-gompi-2023a.eb
+  - STAR-2.7.11a-GCC-12.3.0.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -10,7 +10,8 @@ easyconfigs:
   - HMMER-3.4-gompi-2023a.eb
   - IQ-TREE-2.3.5-gompi-2023a.eb:
       options:
-        from-pr: 20955
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20955
+        from-commit: 185f88b9a03d65a7fb74edc7acb4221e87e90784
   - KronaTools-2.8.1-GCCcore-12.3.0.eb
   - LSD2-2.4.1-GCCcore-12.3.0.eb
   - MAFFT-7.520-GCC-12.3.0-with-extensions.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -8,7 +8,9 @@ easyconfigs:
   - FastME-2.1.6.3-GCC-12.3.0.eb
   - fastp-0.23.4-GCC-12.3.0.eb
   - HMMER-3.4-gompi-2023a.eb
-  - IQ-TREE-2.2.2.7-gompi-2023a.eb
+  - IQ-TREE-2.3.5-gompi-2023a.eb:
+      options:
+        from-pr: 20955
   - KronaTools-2.8.1-GCCcore-12.3.0.eb
   - LSD2-2.4.1-GCCcore-12.3.0.eb
   - MAFFT-7.520-GCC-12.3.0-with-extensions.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -1,7 +1,7 @@
 easyconfigs:
   - grpcio-1.57.0-GCCcore-12.3.0.eb
   - BCFtools-1.18-GCC-12.3.0.eb
-  - BWA-0.7.17-GCCcore-12.3.0.eb
+  - BWA-0.7.18-GCCcore-12.3.0.eb
   - CapnProto-1.0.1-GCCcore-12.3.0.eb
   - DendroPy-4.6.1-GCCcore-12.3.0.eb
   - DIAMOND-2.1.8-GCC-12.3.0.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -14,7 +14,6 @@ easyconfigs:
   - KronaTools-2.8.1-GCCcore-12.3.0.eb
   - LSD2-2.4.1-GCCcore-12.3.0.eb
   - MAFFT-7.520-GCC-12.3.0-with-extensions.eb
-  - MEGAHIT-1.2.9-GCCcore-12.3.0.eb
   - minimap2-2.26-GCCcore-12.3.0.eb
   - MMseqs2-14-7e284-gompi-2023a.eb
   - ncbi-vdb-3.0.10-gompi-2023a.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -14,6 +14,5 @@ easyconfigs:
   - KronaTools-2.8.1-GCCcore-12.3.0.eb
   - LSD2-2.4.1-GCCcore-12.3.0.eb
   - MAFFT-7.520-GCC-12.3.0-with-extensions.eb
-  - minimap2-2.26-GCCcore-12.3.0.eb
   - MMseqs2-14-7e284-gompi-2023a.eb
   - ncbi-vdb-3.0.10-gompi-2023a.eb

--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -17,4 +17,3 @@ easyconfigs:
   - minimap2-2.26-GCCcore-12.3.0.eb
   - MMseqs2-14-7e284-gompi-2023a.eb
   - ncbi-vdb-3.0.10-gompi-2023a.eb
-  - STAR-2.7.11a-GCC-12.3.0.eb


### PR DESCRIPTION
Bio packages found on Saga.

```
missing packages :

BWA-0.7.18-GCCcore-12.3.0.eb       Lic--> GPL3 
CapnProto-1.0.1-GCCcore-12.3.0.eb Lic --> MIT
DendroPy-4.6.1-GCCcore-12.3.0.eb Lic--> MIT/BSD
DIAMOND-2.1.8-GCC-12.3.0.eb Lic --> GPL3 
FastME-2.1.6.3-GCC-12.3.0.eb Lic --> MIT/GPL
fastp-0.23.4-GCC-12.3.0.eb  Lic --> MIT
HMMER-3.4-gompi-2023a.eb Lic --> MIT/GPL
IQ-TREE-2.3.5-gompi-2023a.eb  Lic --> GPL2
KronaTools-2.8.1-GCCcore-12.3.0.eb Lic --> FREE(https://raw.githubusercontent.com/marbl/Krona/master/KronaTools/LICENSE.txt)
LSD2-2.4.1-GCCcore-12.3.0.eb Lic--> GPL2
MAFFT-7.520-GCC-12.3.0-with-extensions.eb Lic --> BSD
MMseqs2-14-7e284-gompi-2023a.eb --> GPL3
ncbi-vdb-3.0.10-gompi-2023a.eb Lic --> Public Domain
```