### PR TITLE
{2023.06}[foss/2023a] phonopy V2.20.0

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -17,3 +17,4 @@ easyconfigs:
   - MAFFT-7.520-GCC-12.3.0-with-extensions.eb
   - MMseqs2-14-7e284-gompi-2023a.eb
   - ncbi-vdb-3.0.10-gompi-2023a.eb
+  - phonopy-2.20.0-foss-2023a.eb


### PR DESCRIPTION
phonopy-2.20.0 is found on Saga
Lic --> BSD

```
missing packages :
phonopy/2.20.0-foss-2023a
```