### PR TITLE
{2023.06}[foss/2023a] GPAW V24.1.0

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -18,3 +18,4 @@ easyconfigs:
   - MMseqs2-14-7e284-gompi-2023a.eb
   - ncbi-vdb-3.0.10-gompi-2023a.eb
   - phonopy-2.20.0-foss-2023a.eb
+  - GPAW-24.1.0-foss-2023a.eb


### PR DESCRIPTION
GPAW/24.1.0 is found on Saga
Lic --> https://spdx.org/licenses/GPL-3.0-or-later.html

```
missing packages:
GPAW/24.1.0-foss-2023a
```