### PR TITLE
{2023.06}[foss/2022b] PETSc V3.19.2

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - PETSc-3.19.2-foss-2022b.eb


### PR DESCRIPTION
PETSc-3.19.2 is found on Saga
```
8 out of 65 required modules missing:

* METIS/5.1.0-GCCcore-12.2.0 (METIS-5.1.0-GCCcore-12.2.0.eb)
* ParMETIS/4.0.3-gompi-2022b (ParMETIS-4.0.3-gompi-2022b.eb)
* SCOTCH/7.0.3-gompi-2022b (SCOTCH-7.0.3-gompi-2022b.eb)
* Hypre/2.27.0-foss-2022b (Hypre-2.27.0-foss-2022b.eb)
* SuperLU_DIST/8.1.2-foss-2022b (SuperLU_DIST-8.1.2-foss-2022b.eb)
* MUMPS/5.6.1-foss-2022b-metis (MUMPS-5.6.1-foss-2022b-metis.eb)
* SuiteSparse/5.13.0-foss-2022b-METIS-5.1.0 (SuiteSparse-5.13.0-foss-2022b-METIS-5.1.0.eb)
* PETSc/3.19.2-foss-2022b (PETSc-3.19.2-foss-2022b.eb)

```