### PR TITLE
{2023.06}[foss/2022b] WhatsHap V2.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - WhatsHap-2.1-foss-2022b.eb


### PR DESCRIPTION
WhatsHap-2.1-foss-2022b is found on Saga
Lic --> MIT
```
missing packages:

ISA-L/2.30.0-GCCcore-12.2.0
pyfaidx/0.7.2.1-GCCcore-12.2.0
Pysam/0.21.0-GCC-12.2.0
python-isal/1.1.0-GCCcore-12.2.0
WhatsHap/2.1-foss-2022b
```