### PR TITLE
{2023.06}[gfbf/2023b] pystencils V1.3.4

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023b.yml
@@ -1,2 +1,6 @@
 easyconfigs:
   - dlb-3.4-gompi-2023b.eb
+  - pystencils-1.3.4-gfbf-2023b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20889
+        from-commit: c66c4788a17f7e4f55aa23f9fdb782aad97c9ce7


### PR DESCRIPTION
Sync with EESSI ( PR 641)
Lic --> AGPLv3+

```
missing packages :

gmpy2/2.1.5-GCC-13.2.0
libyaml/0.2.5-GCCcore-13.2.0
pystencils/1.3.4-gfbf-2023b
PyYAML/6.0.1-GCCcore-13.2.0
sympy/1.12-gfbf-2023b

```