### PR TITLE
{2023.06}[gompi/2022b] BLAST+ V2.14.0

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
@@ -1,2 +1,5 @@
 easyconfigs:
   - WhatsHap-2.1-foss-2022b.eb
+  - BLAST+-2.14.0-gompi-2022b.eb:
+      options:
+        from-commit: 1775912a1d36101d560e1355967732b07e82cd24


### PR DESCRIPTION
BLAST+ V2.14.0 is found on Saga
Lic --> check NCBI licenses
```
3 out of 42 required modules missing:

* cpio/2.15-GCCcore-12.2.0 (cpio-2.15-GCCcore-12.2.0.eb)
* LMDB/0.9.29-GCCcore-12.2.0 (LMDB-0.9.29-GCCcore-12.2.0.eb)
* BLAST+/2.14.0-gompi-2022b (BLAST+-2.14.0-gompi-2022b.eb)

```