### PR TITLE
{2023.06}[foss/2023a] MetalWalls V21.06.1

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -20,3 +20,4 @@ easyconfigs:
   - phonopy-2.20.0-foss-2023a.eb
   - GPAW-24.1.0-foss-2023a.eb
   - DB_File-1.859-GCCcore-12.3.0.eb
+  - MetalWalls-21.06.1-foss-2023a.eb


### PR DESCRIPTION
Lic --> MIT
```
missing packages:

f90wrap/0.2.13-foss-2023a
Meson/1.3.1-GCCcore-12.3.0
meson-python/0.15.0-GCCcore-12.3.0
MetalWalls/21.06.1-foss-2023a
```