### PR TITLE
fix `${cvmfs_repo_name}` in EESSI_WRITABLE_OVERLAY when merging all lower directories

### DIFF
--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -769,7 +769,7 @@ do
           # need to convert ':' in LOWER_DIRS to ',' because bind mounts use ',' as
           # separator while the lowerdir overlayfs option uses ':'
           export BIND_PATHS="${BIND_PATHS},${LOWER_DIRS/:/,}"
-          EESSI_WRITABLE_OVERLAY+=" -o lowerdir=${LOWER_DIRS}:/cvmfs_ro/${repo_name}"
+          EESSI_WRITABLE_OVERLAY+=" -o lowerdir=${LOWER_DIRS}:/cvmfs_ro/${cvmfs_repo_name}"
         else
         EESSI_WRITABLE_OVERLAY+=" -o lowerdir=/cvmfs_ro/${cvmfs_repo_name}"
         fi


### PR DESCRIPTION
When merging all lower directories, we are ending up in: 

```
singularity  run  --fusemount container:cvmfs2 pilot.nessi.no /cvmfs_ro/pilot.nessi.no --fusemount container:fuse-overlayfs -o lowerdir=/tmp/nessibot/14903/NESSI/lower_dirs:/cvmfs_ro/ -o upperdir=/tmp/pilot.nessi.no/overlay-upper -o workdir=/tmp/pilot.nessi.no/overlay-work /cvmfs/pilot.nessi.no /tmp/nessibot/14903/NESSI/eessi.1kJcn9xcrp/ghcr.io_eessi_build_node_debian11.sif ./EESSI-remove-software.sh

```