### PR TITLE
{2023.06}[foss/2023b] pyMBE V0.8.0

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2023b.yml
@@ -4,3 +4,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20889
         from-commit: c66c4788a17f7e4f55aa23f9fdb782aad97c9ce7
+  - pyMBE-0.8.0-foss-2023b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21034
+        from-commit: 76e7fc6657bab64bfbec826540a3a8f0040258f2


### PR DESCRIPTION
Sync with EESSI ( PR  651)
Lic --> GPL-3.0
```
missing packages:

Boost.MPI/1.83.0-gompi-2023b
ESPResSo/4.2.2-foss-2023b
Pint/0.24-GCCcore-13.2.0
pyMBE/0.8.0-foss-2023b
```