### PR TITLE
{2023.06}[foss/2022b] BUSCO V5.4.7

### DIFF
--- a/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
+++ b/easystacks/pilot.nessi.no/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
@@ -3,3 +3,4 @@ easyconfigs:
   - BLAST+-2.14.0-gompi-2022b.eb:
       options:
         from-commit: 1775912a1d36101d560e1355967732b07e82cd24
+  - BUSCO-5.4.7-foss-2022b.eb


### PR DESCRIPTION
BUSCO-5.4.7 is found on Saga
Lic -->
```
13 out of 159 required modules missing:

* prodigal/2.6.3-GCCcore-12.2.0 (prodigal-2.6.3-GCCcore-12.2.0.eb)
* MetaEuk/6-GCC-12.2.0 (MetaEuk-6-GCC-12.2.0.eb)
* SAMtools/1.17-GCC-12.2.0 (SAMtools-1.17-GCC-12.2.0.eb)
* HTSlib/1.17-GCC-12.2.0 (HTSlib-1.17-GCC-12.2.0.eb)
* BCFtools/1.17-GCC-12.2.0 (BCFtools-1.17-GCC-12.2.0.eb)
* lpsolve/5.5.2.11-GCC-12.2.0 (lpsolve-5.5.2.11-GCC-12.2.0.eb)
* HMMER/3.3.2-gompi-2022b (HMMER-3.3.2-gompi-2022b.eb)
* BBMap/39.01-GCC-12.2.0 (BBMap-39.01-GCC-12.2.0.eb)
* BamTools/2.5.2-GCC-12.2.0 (BamTools-2.5.2-GCC-12.2.0.eb)
* METIS/5.1.0-GCCcore-12.2.0 (METIS-5.1.0-GCCcore-12.2.0.eb)
* SuiteSparse/5.13.0-foss-2022b-METIS-5.1.0 (SuiteSparse-5.13.0-foss-2022b-METIS-5.1.0.eb)
* AUGUSTUS/3.5.0-foss-2022b (AUGUSTUS-3.5.0-foss-2022b.eb)
* BUSCO/5.4.7-foss-2022b (BUSCO-5.4.7-foss-2022b.eb)

```